### PR TITLE
Use getAlias instead of getAliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+## [2.0.3] - 2019-08-26
+### Fixed
+- Elasticsearch 7.2 compatibility
+
 ## [2.0.2] - 2019-05-10
 ### Added
 - Search amongst multiple models

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "matchish/laravel-scout-elasticsearch",
     "description": "This package extends Laravel Scout adding full power of ElasticSearch",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "keywords": [
         "laravel",
         "scout",
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "elasticsearch/elasticsearch": ">=7.0 <7.2",
+        "elasticsearch/elasticsearch": ">=7.2",
         "laravel/scout": "^6.1.1|^7.0",
         "ongr/elasticsearch-dsl": "^6.0"
     },

--- a/src/Jobs/Stages/CleanUp.php
+++ b/src/Jobs/Stages/CleanUp.php
@@ -34,7 +34,7 @@ final class CleanUp
         $params = GetAliasParams::anyIndex($searchable->searchableAs());
         try {
             /** @var array $response */
-            $response = $elasticsearch->indices()->getAliases($params->toArray());
+            $response = $elasticsearch->indices()->getAlias($params->toArray());
         } catch (Missing404Exception $e) {
             $response = [];
         }

--- a/src/Jobs/Stages/SwitchToNewAndRemoveOldIndex.php
+++ b/src/Jobs/Stages/SwitchToNewAndRemoveOldIndex.php
@@ -38,7 +38,7 @@ final class SwitchToNewAndRemoveOldIndex
         $searchable = $this->searchable;
         $params = Get::anyIndex($searchable->searchableAs());
         /** @var array $response */
-        $response = $elasticsearch->indices()->getAliases($params->toArray());
+        $response = $elasticsearch->indices()->getAlias($params->toArray());
 
         $params = new Update();
         foreach ($response as $indexName => $alias) {

--- a/tests/Integration/Jobs/Stages/CreateWriteIndexTest.php
+++ b/tests/Integration/Jobs/Stages/CreateWriteIndexTest.php
@@ -17,7 +17,7 @@ final class CreateWriteIndexTest extends IntegrationTestCase
         $elasticsearch = $this->app->make(Client::class);
         $stage = new CreateWriteIndex(new Product(), Index::fromSearchable(new Product()));
         $stage->handle($elasticsearch);
-        $response = $elasticsearch->indices()->getAliases(['index' => '*', 'name' => 'products']);
+        $response = $elasticsearch->indices()->getAlias(['index' => '*', 'name' => 'products']);
         $this->assertTrue($this->containsWriteIndex($response, 'products'));
     }
 


### PR DESCRIPTION
Elasticsearch\Namespaces\IndicesNamespace::getAliases() removed in 7.2 version  
https://github.com/matchish/laravel-scout-elasticsearch/issues/40