### PR TITLE
Use Interface to Allow Custom Binding of HitsIteratorAggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+## [2.0.3] - 2019-09-09
+### Added
+- Added interface binding for HitsIteratorAggregate for custom implementation
+
 ## [2.0.2] - 2019-05-10
 ### Added
 - Search amongst multiple models

--- a/src/ElasticSearch/HitsIteratorAggregate.php
+++ b/src/ElasticSearch/HitsIteratorAggregate.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Matchish\ScoutElasticSearch\ElasticSearch;
+
+interface HitsIteratorAggregate extends \IteratorAggregate
+{
+    public function __construct(array $results, callable $callback = null);
+
+    public function getIterator();
+}

--- a/src/ElasticSearchServiceProvider.php
+++ b/src/ElasticSearchServiceProvider.php
@@ -18,6 +18,11 @@ final class ElasticSearchServiceProvider extends ServiceProvider
         $this->app->bind(Client::class, function () {
             return ClientBuilder::create()->setHosts([config('elasticsearch.host')])->build();
         });
+
+        $this->app->bind(
+            'Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate',
+            'Matchish\ScoutElasticSearch\ElasticSearch\EloquentHitsIteratorAggregate'
+        );
     }
 
     /**

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -11,8 +11,8 @@ use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Bulk;
 use Matchish\ScoutElasticSearch\ElasticSearch\SearchFactory;
 use Matchish\ScoutElasticSearch\ElasticSearch\SearchResults;
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Refresh;
-use Matchish\ScoutElasticSearch\ElasticSearch\EloquentHitsIteratorAggregate;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Search as SearchParams;
 
 final class ElasticSearchEngine extends Engine
@@ -27,7 +27,7 @@ final class ElasticSearchEngine extends Engine
     /**
      * Create a new engine instance.
      *
-     * @param  \Elasticsearch\Client $elasticsearch
+     * @param \Elasticsearch\Client $elasticsearch
      * @return void
      */
     public function __construct(\Elasticsearch\Client $elasticsearch)
@@ -102,7 +102,10 @@ final class ElasticSearchEngine extends Engine
      */
     public function map(BaseBuilder $builder, $results, $model)
     {
-        $hits = new EloquentHitsIteratorAggregate($results, $builder->queryCallback);
+        $hits = app()->makeWith(HitsIteratorAggregate::class,
+                    ['results' => $results,
+                    'callback' => $builder->queryCallback,
+                    ]);
 
         return new Collection($hits);
     }

--- a/tests/Integration/Elasticsearch/HitsIteratorAggregateTest.php
+++ b/tests/Integration/Elasticsearch/HitsIteratorAggregateTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Matchish\ScoutElasticSearch;
+
+use Tests\TestCase;
+use App\Library\CustomHitsIteratorAggregate;
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+use Matchish\ScoutElasticSearch\ElasticSearch\EloquentHitsIteratorAggregate;
+
+class HitsIteratorAggregateTest extends TestCase
+{
+    public function test_hits_iterator_aggregate_binds_to_eloquent_implementation()
+    {
+        $iteratorAggregate = $this->app->makeWith(HitsIteratorAggregate::class, [
+                                                'results' => [],
+                                                'callback' => null,
+                                            ]);
+
+        $this->assertEquals(EloquentHitsIteratorAggregate::class, get_class($iteratorAggregate));
+    }
+
+    public function test_override_bind_for_custom_iterator_aggregate_implementation()
+    {
+        $this->app->bind(HitsIteratorAggregate::class, CustomHitsIteratorAggregate::class);
+
+        $iteratorAggregate = $this->app->makeWith(HitsIteratorAggregate::class, [
+                                                'results' => [],
+                                                'callback' => null,
+                                            ]);
+
+        $this->assertEquals(CustomHitsIteratorAggregate::class, get_class($iteratorAggregate));
+    }
+}

--- a/tests/laravel/app/library/CustomHitsIteratorAggregate.php
+++ b/tests/laravel/app/library/CustomHitsIteratorAggregate.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Library;
+
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+
+class CustomHitsIteratorAggregate implements HitsIteratorAggregate
+{
+    private $hits;
+
+    private $callback;
+
+    public function __construct(array $results, callable $callback = null)
+    {
+        $this->results = $results;
+
+        $this->callback = $callback;
+    }
+
+    public function getIterator()
+    {
+        $hits = ['test1', 'test2', 'test3'];
+
+        return new \ArrayIterator($hits);
+    }
+}


### PR DESCRIPTION
Added an interface "HitsIteratorAggregate" that is used in the elastic scout engine's map method when parsing elasticsearch results. 

```php
 public function map(BaseBuilder $builder, $results, $model)
  {

        $hits = app()->makeWith(HitsIteratorAggregate::class, 
                    ['results' => $results, 
                    'callback' => $builder->queryCallback
                    ]);

        return new Collection($hits);
  }
```

It would allow users to define their own implementation by simply overriding the binding in the AppServiceProvider's register method. 

```php
public function register()
{

    $this->app->bind(HitsIteratorAggregate::class, CustomHitsIteratorAggregate::class);

}
```

It currently defaults to the packages EloquentHitsIteratorAggregate in the ElasticSearchServiceProvider class.

```php
$this->app->bind(
     'Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate',
     'Matchish\ScoutElasticSearch\ElasticSearch\EloquentHitsIteratorAggregate'
);
```

Currently tested on elasticsearch-7 branch.