### PR TITLE
Fixed ->paginate in models

### DIFF
--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -113,7 +113,7 @@ final class ElasticSearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results['hits']['total'];
+        return $results['hits']['total']['value'];
     }
 
     /**


### PR DESCRIPTION
Update getTotalCount in order to fix the ->paginate method in the models. Currently the method returns an array and it creates an Exception in the default Laravel paginator