### PR TITLE
Allow custom hits iterator

### DIFF
--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -20,6 +20,9 @@ final class SearchFactory
     {
         $search = new Search();
         $query = new QueryStringQuery($builder->query);
+        if(isset($options['fields'])){
+            $query->addParameter('fields', $options['fields']);
+        }
         if (! empty($builder->wheres)) {
             $boolQuery = new BoolQuery();
             foreach ($builder->wheres as $field => $value) {


### PR DESCRIPTION
This is probably not what you had in mind for this as it alters the engine away from the Laravel scout builder abstract as well as exposing the engine within the search callback.

My reason for doing it this way is purely thinking about the API as to how I would like to be able to set different iterators on a search by search basis.

I would be interested to get your thoughts on how you see this working. This is really just to open a discussion more than anything.

An example of its use:

```php
$model::search($query,
    function (Client $client, Search $body, ElasticSearchEngine $engine) use ($model, $field, $query) {
        $engine->useHitsIterator(HighlighterHitsIteratorAggregate::class);
        $highlight = new Highlight();
        $highlight->addField($field);
        $body->addHighlight($highlight);
        return $client->search(['index' => $model->searchableAs(), 'body' => $body->toArray()]);
    })->paginate(100);
```