### PR TITLE
Use soft delete only when available and configured to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+## [3.0.1] - 2020-03-02
+### Fixed
+-  Respect the model uses soft delete
+
 ## [3.0.0] - 2019-11-17
 ### Added
 - Elasticsearch 7 support

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "matchish/laravel-scout-elasticsearch",
     "description": "Search among multiple models with ElasticSearch and Laravel Scout",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "keywords": [
         "laravel",
         "scout",

--- a/src/Searchable/DefaultImportSource.php
+++ b/src/Searchable/DefaultImportSource.php
@@ -66,7 +66,7 @@ final class DefaultImportSource implements ImportSource
     private function newQuery()
     {
         $query = $this->model()->newQuery();
-        $softDelete = config('scout.soft_delete', false);
+        $softDelete = $this->className::usesSoftDelete() && config('scout.soft_delete', false);
         $query
             ->when($softDelete, function ($query) {
                 return $query->withTrashed();


### PR DESCRIPTION
Hi @matchish,

Thank you for the work you did on this great driver!

I wanted to make an attribution to have it work a bit smoother when soft deletes are used trough Scout. 

Similarly as being done here:

`\Matchish\ScoutElasticSearch\ElasticSearch\Params\Bulk`

```php
    public function toArray(): array
    {
        $payload = ['body' => []];
        $payload = collect($this->indexDocs)->reduce(
            function ($payload, $model) {
                if ($model::usesSoftDelete() && config('scout.soft_delete', false)) {
                    $model->pushSoftDeleteMetadata();
                }
```
I am using soft deletes, but not on all my models. This MR would help me out, because now I get an exception on models without soft deletes:

`BadMethodCallException  : Call to undefined method Illuminate\Database\Eloquent\Builder::withTrashed()`