### PR TITLE
Don't use searchable macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+## [4.0.1] - 2020-03-26
+### Fixed
+-  Prevent unnessasary send `\Laravel\Scout\Jobs\MakeSearchable` to a queue
+
 ## [4.0.0] - 2020-03-12
 ### Added
 -  Scout 8 Support

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "matchish/laravel-scout-elasticsearch",
     "description": "Search among multiple models with ElasticSearch and Laravel Scout",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "keywords": [
         "laravel",
         "scout",

--- a/src/Jobs/Stages/PullFromSource.php
+++ b/src/Jobs/Stages/PullFromSource.php
@@ -25,8 +25,10 @@ final class PullFromSource
 
     public function handle(): void
     {
-        $results = $this->source->get();
-        $results->filter->shouldBeSearchable()->searchable();
+        $results = $this->source->get()->filter->shouldBeSearchable();
+        if (!$results->isEmpty()) {
+            $results->first()->searchableUsing()->update($results);
+        }
     }
 
     public function estimate(): int


### PR DESCRIPTION
`searchable` macros send `MakeSearchable`  job to a queue. And I want to prevent it

https://github.com/matchish/laravel-scout-elasticsearch/issues/105