### PR TITLE
Fixes `import` to `reimport`

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ class WithCommentsScope implements Scope {
 }
 ```
 ### Zero downtime reimport
-While working in production, to keep your existing search experience available while reimporting your data, you also can use `scout:import` Artisan command:  
+While working in production, to keep your existing search experience available while reimporting your data, you also can use `scout:reimport` Artisan command:  
 
-`php artisan scout:import`
+`php artisan scout:reimport`
 
 The command create new temporary index, import all models to it, and then switch to the index and remove old index.
 


### PR DESCRIPTION
Fixes `import` typo to `reimport`