### PR TITLE
Allow extending DefaultImportSource to provide customization to indexing definitions

### DIFF
--- a/src/ElasticSearch/Index.php
+++ b/src/ElasticSearch/Index.php
@@ -2,11 +2,6 @@
 
 namespace Matchish\ScoutElasticSearch\ElasticSearch;
 
-use Matchish\ScoutElasticSearch\Searchable\ImportSource;
-
-/**
- * @internal
- */
 final class Index
 {
     /**
@@ -81,21 +76,5 @@ final class Index
         }
 
         return $config;
-    }
-
-    public static function fromSource(ImportSource $source): Index
-    {
-        $name = $source->searchableAs().'_'.time();
-        $settingsConfigKey = "elasticsearch.indices.settings.{$source->searchableAs()}";
-        $mappingsConfigKey = "elasticsearch.indices.mappings.{$source->searchableAs()}";
-        $defaultSettings = [
-            'number_of_shards' => 1,
-            'number_of_replicas' => 0,
-
-        ];
-        $settings = config($settingsConfigKey, config('elasticsearch.indices.settings.default', $defaultSettings));
-        $mappings = config($mappingsConfigKey, config('elasticsearch.indices.mappings.default'));
-
-        return new static($name, $settings, $mappings);
     }
 }

--- a/src/Jobs/ImportStages.php
+++ b/src/Jobs/ImportStages.php
@@ -3,7 +3,6 @@
 namespace Matchish\ScoutElasticSearch\Jobs;
 
 use Illuminate\Support\Collection;
-use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 use Matchish\ScoutElasticSearch\Jobs\Stages\CleanUp;
 use Matchish\ScoutElasticSearch\Jobs\Stages\CreateWriteIndex;
 use Matchish\ScoutElasticSearch\Jobs\Stages\PullFromSource;
@@ -19,7 +18,7 @@ class ImportStages extends Collection
      */
     public static function fromSource(ImportSource $source)
     {
-        $index = Index::fromSource($source);
+        $index = $source->defineIndex();
 
         return (new self([
             new CleanUp($source),

--- a/src/Searchable/ImportSource.php
+++ b/src/Searchable/ImportSource.php
@@ -4,6 +4,7 @@ namespace Matchish\ScoutElasticSearch\Searchable;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
+use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 
 interface ImportSource
 {
@@ -15,5 +16,9 @@ interface ImportSource
 
     public function chunked(): Collection;
 
+    public function getChunkSize(): int;
+
     public function get(): EloquentCollection;
+
+    public function defineIndex(): Index;
 }

--- a/tests/Integration/Engines/ElasticSearchEngineTest.php
+++ b/tests/Integration/Engines/ElasticSearchEngineTest.php
@@ -4,7 +4,6 @@ namespace Tests\Integration\Engines;
 
 use App\Product;
 use Laravel\Scout\Builder;
-use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Create;
 use Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine;
 use Matchish\ScoutElasticSearch\Searchable\DefaultImportSourceFactory;
@@ -67,7 +66,7 @@ final class ElasticSearchEngineTest extends IntegrationTestCase
 
             return $model;
         });
-        $index = Index::fromSource(DefaultImportSourceFactory::from(Product::class));
+        $index = DefaultImportSourceFactory::from(Product::class)->defineIndex();
         $params = new Create(
             'products',
             $index->config()

--- a/tests/Integration/Jobs/Stages/CreateWriteIndexTest.php
+++ b/tests/Integration/Jobs/Stages/CreateWriteIndexTest.php
@@ -6,7 +6,6 @@ namespace Tests\Integration\Jobs\Stages;
 
 use App\Product;
 use Elasticsearch\Client;
-use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 use Matchish\ScoutElasticSearch\Jobs\Stages\CreateWriteIndex;
 use Matchish\ScoutElasticSearch\Searchable\DefaultImportSourceFactory;
 use Tests\IntegrationTestCase;
@@ -16,7 +15,8 @@ final class CreateWriteIndexTest extends IntegrationTestCase
     public function test_create_write_index(): void
     {
         $elasticsearch = $this->app->make(Client::class);
-        $stage = new CreateWriteIndex(DefaultImportSourceFactory::from(Product::class), Index::fromSource(DefaultImportSourceFactory::from(Product::class)));
+        $source = DefaultImportSourceFactory::from(Product::class);
+        $stage = new CreateWriteIndex($source, $source->defineIndex());
         $stage->handle($elasticsearch);
         $response = $elasticsearch->indices()->getAlias(['index' => '*', 'name' => 'products']);
         $this->assertTrue($this->containsWriteIndex($response, 'products'));

--- a/tests/Unit/ElasticSearch/IndexTest.php
+++ b/tests/Unit/ElasticSearch/IndexTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit\ElasticSearch;
 
 use App\Product;
-use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 use Matchish\ScoutElasticSearch\Searchable\DefaultImportSourceFactory;
 use Tests\TestCase;
 
@@ -11,12 +10,12 @@ class IndexTest extends TestCase
 {
     public function test_creation_from_searchable()
     {
-        $index = Index::fromSource(DefaultImportSourceFactory::from(Product::class));
+        $index = DefaultImportSourceFactory::from(Product::class)->defineIndex();
         $this->assertEquals($index->name(), 'products_1525376494');
     }
 }
 
-namespace Matchish\ScoutElasticSearch\ElasticSearch;
+namespace Matchish\ScoutElasticSearch\Searchable;
 
 function time(): int
 {


### PR DESCRIPTION
Allow DefaultImportSource to be extendable
- Allow overriding default chunk size

Move Index creation from static method on Index to a method of ImportSource.
 - Allow custom index rules to be applied to generating Indexes if DefaultImportSource is extended.