### PR TITLE
Because without scroll the total is incorrect

### DIFF
--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -36,6 +36,9 @@ final class SearchFactory
         if (array_key_exists('size', $options)) {
             $search->setSize($options['size']);
         }
+        if (array_key_exists('scroll', $options)) {
+            $search->setScroll($options['scroll']);
+        }
         if (! empty($builder->orders)) {
             foreach ($builder->orders as $order) {
                 $search->addSort(new FieldSort($order['column'], $order['direction']));

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -85,11 +85,12 @@ final class ElasticSearchEngine extends Engine
     /**
      * {@inheritdoc}
      */
-    public function paginate(BaseBuilder $builder, $perPage, $page)
+    public function paginate(BaseBuilder $builder, $perPage, $page, $scroll = '5m')
     {
         return $this->performSearch($builder, [
             'from' => ($page - 1) * $perPage,
             'size' => $perPage,
+            'scroll' => $scroll,
         ]);
     }
 

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -85,7 +85,7 @@ final class ElasticSearchEngine extends Engine
     /**
      * {@inheritdoc}
      */
-    public function paginate(BaseBuilder $builder, $perPage, $page, $scroll = '5m')
+    public function paginate(BaseBuilder $builder, $perPage, $page, string $scroll = '5m')
     {
         return $this->performSearch($builder, [
             'from' => ($page - 1) * $perPage,


### PR DESCRIPTION
This adds the scroll as an URI argument which is otherwise unable to be set from what I can see. Without the scroll the result set is always listed as a max of 10000 when using pagination.