### PR TITLE
[^] Fixed SQL statements getting slower and slower when importing big…

### DIFF
--- a/src/Database/Scopes/ChunkScope.php
+++ b/src/Database/Scopes/ChunkScope.php
@@ -25,25 +25,25 @@ class ChunkScope implements Scope
     public function __construct($start, $end)
     {
         $this->start = $start;
-        $this->end   = $end;
+        $this->end = $end;
     }
 
     /**
      * Apply the scope to a given Eloquent query builder.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder $builder
-     * @param  \Illuminate\Database\Eloquent\Model   $model
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
     public function apply(Builder $builder, Model $model)
     {
         $start = $this->start;
-        $end   = $this->end;
+        $end = $this->end;
         $builder
-            ->when(!is_null($start), function ($query) use ($start, $model) {
+            ->when(! is_null($start), function ($query) use ($start, $model) {
                 return $query->where($model->getKeyName(), '>', $start);
             })
-            ->when(!is_null($end), function ($query) use ($end, $model) {
+            ->when(! is_null($end), function ($query) use ($end, $model) {
                 return $query->where($model->getKeyName(), '<=', $end);
             });
     }

--- a/src/Database/Scopes/ChunkScope.php
+++ b/src/Database/Scopes/ChunkScope.php
@@ -25,25 +25,25 @@ class ChunkScope implements Scope
     public function __construct($start, $end)
     {
         $this->start = $start;
-        $this->end = $end;
+        $this->end   = $end;
     }
 
     /**
      * Apply the scope to a given Eloquent query builder.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Model   $model
      * @return void
      */
     public function apply(Builder $builder, Model $model)
     {
         $start = $this->start;
-        $end = $this->end;
+        $end   = $this->end;
         $builder
-            ->when(! is_null($start), function ($query) use ($start, $model) {
+            ->when(!is_null($start), function ($query) use ($start, $model) {
                 return $query->where($model->getKeyName(), '>', $start);
             })
-            ->when(! is_null($end), function ($query) use ($end, $model) {
+            ->when(!is_null($end), function ($query) use ($end, $model) {
                 return $query->where($model->getKeyName(), '<=', $end);
             });
     }

--- a/src/Database/Scopes/PageScope.php
+++ b/src/Database/Scopes/PageScope.php
@@ -25,7 +25,7 @@ class PageScope implements Scope
      */
     public function __construct(int $page, int $perPage)
     {
-        $this->page = $page;
+        $this->page    = $page;
         $this->perPage = $perPage;
     }
 
@@ -33,11 +33,11 @@ class PageScope implements Scope
      * Apply the scope to a given Eloquent query builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
-     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param \Illuminate\Database\Eloquent\Model   $model
      * @return void
      */
     public function apply(Builder $builder, Model $model)
     {
-        $builder->forPageAfterId($this->perPage,Cache::get('scout_import_last_id',0),$model->getKeyName());
+        $builder->forPageAfterId($this->perPage, Cache::get('scout_import_last_id', 0), $model->getKeyName());
     }
 }

--- a/src/Database/Scopes/PageScope.php
+++ b/src/Database/Scopes/PageScope.php
@@ -25,7 +25,7 @@ class PageScope implements Scope
      */
     public function __construct(int $page, int $perPage)
     {
-        $this->page    = $page;
+        $this->page = $page;
         $this->perPage = $perPage;
     }
 

--- a/src/Database/Scopes/PageScope.php
+++ b/src/Database/Scopes/PageScope.php
@@ -5,6 +5,7 @@ namespace Matchish\ScoutElasticSearch\Database\Scopes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\Cache;
 
 class PageScope implements Scope
 {
@@ -37,6 +38,6 @@ class PageScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        $builder->forPage($this->page, $this->perPage);
+        $builder->forPageAfterId($this->perPage,Cache::get('scout_import_last_id',0),$model->getKeyName());
     }
 }

--- a/src/Jobs/ImportStages.php
+++ b/src/Jobs/ImportStages.php
@@ -25,7 +25,7 @@ class ImportStages extends Collection
         return (new self([
             new CleanUp($source),
             new CreateWriteIndex($source, $index),
-            new CleanLastId(),// Cleans the last ID of the cache left over from the last time
+            new CleanLastId(), // Cleans the last ID of the cache left over from the last time
             PullFromSource::chunked($source),
             new RefreshIndex($index),
             new SwitchToNewAndRemoveOldIndex($source, $index),

--- a/src/Jobs/ImportStages.php
+++ b/src/Jobs/ImportStages.php
@@ -4,6 +4,7 @@ namespace Matchish\ScoutElasticSearch\Jobs;
 
 use Illuminate\Support\Collection;
 use Matchish\ScoutElasticSearch\ElasticSearch\Index;
+use Matchish\ScoutElasticSearch\Jobs\Stages\CleanLastId;
 use Matchish\ScoutElasticSearch\Jobs\Stages\CleanUp;
 use Matchish\ScoutElasticSearch\Jobs\Stages\CreateWriteIndex;
 use Matchish\ScoutElasticSearch\Jobs\Stages\PullFromSource;
@@ -24,6 +25,7 @@ class ImportStages extends Collection
         return (new self([
             new CleanUp($source),
             new CreateWriteIndex($source, $index),
+            new CleanLastId(),//Cleans the last ID of the cache left over from the last time
             PullFromSource::chunked($source),
             new RefreshIndex($index),
             new SwitchToNewAndRemoveOldIndex($source, $index),

--- a/src/Jobs/ImportStages.php
+++ b/src/Jobs/ImportStages.php
@@ -25,7 +25,7 @@ class ImportStages extends Collection
         return (new self([
             new CleanUp($source),
             new CreateWriteIndex($source, $index),
-            new CleanLastId(),//Cleans the last ID of the cache left over from the last time
+            new CleanLastId(),// Cleans the last ID of the cache left over from the last time
             PullFromSource::chunked($source),
             new RefreshIndex($index),
             new SwitchToNewAndRemoveOldIndex($source, $index),

--- a/src/Jobs/Stages/CleanLastId.php
+++ b/src/Jobs/Stages/CleanLastId.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Matchish\ScoutElasticSearch\Jobs\Stages;
+
+use Elasticsearch\Client;
+use Elasticsearch\Common\Exceptions\Missing404Exception;
+use Illuminate\Support\Facades\Cache;
+use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Alias\Get as GetAliasParams;
+use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Delete as DeleteIndexParams;
+use Matchish\ScoutElasticSearch\Searchable\ImportSource;
+
+/**
+ * @internal
+ */
+final class CleanLastId
+{
+    /**
+     * @var ImportSource
+     */
+    private $source;
+
+    /**
+     * @param ImportSource $source
+     */
+    public function __construct()
+    {
+
+    }
+
+    public function handle(Client $elasticsearch): void
+    {
+        // Clean Last id
+        Cache::forget('scout_import_last_id');
+    }
+
+    public function title(): string
+    {
+        return 'Clean Last Id';
+    }
+
+    public function estimate(): int
+    {
+        return 1;
+    }
+}

--- a/src/Jobs/Stages/CleanLastId.php
+++ b/src/Jobs/Stages/CleanLastId.php
@@ -3,7 +3,6 @@
 namespace Matchish\ScoutElasticSearch\Jobs\Stages;
 
 use Elasticsearch\Client;
-use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Illuminate\Support\Facades\Cache;
 use Matchish\ScoutElasticSearch\Searchable\ImportSource;
 

--- a/src/Jobs/Stages/CleanLastId.php
+++ b/src/Jobs/Stages/CleanLastId.php
@@ -5,8 +5,6 @@ namespace Matchish\ScoutElasticSearch\Jobs\Stages;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Illuminate\Support\Facades\Cache;
-use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Alias\Get as GetAliasParams;
-use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Delete as DeleteIndexParams;
 use Matchish\ScoutElasticSearch\Searchable\ImportSource;
 
 /**

--- a/src/Jobs/Stages/CleanLastId.php
+++ b/src/Jobs/Stages/CleanLastId.php
@@ -24,7 +24,6 @@ final class CleanLastId
      */
     public function __construct()
     {
-
     }
 
     public function handle(Client $elasticsearch): void

--- a/src/Jobs/Stages/PullFromSource.php
+++ b/src/Jobs/Stages/PullFromSource.php
@@ -3,6 +3,7 @@
 namespace Matchish\ScoutElasticSearch\Jobs\Stages;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Matchish\ScoutElasticSearch\Searchable\ImportSource;
 
 /**
@@ -27,6 +28,9 @@ final class PullFromSource
     {
         $results = $this->source->get()->filter->shouldBeSearchable();
         if (! $results->isEmpty()) {
+            // Cache last id
+            Cache::put('scout_import_last_id',$results->last()->getKey());
+
             $results->first()->searchableUsing()->update($results);
         }
     }

--- a/src/Jobs/Stages/PullFromSource.php
+++ b/src/Jobs/Stages/PullFromSource.php
@@ -27,9 +27,9 @@ final class PullFromSource
     public function handle(): void
     {
         $results = $this->source->get()->filter->shouldBeSearchable();
-        if (! $results->isEmpty()) {
+        if (!$results->isEmpty()) {
             // Cache last id
-            Cache::put('scout_import_last_id',$results->last()->getKey());
+            Cache::put('scout_import_last_id', $results->last()->getKey());
 
             $results->first()->searchableUsing()->update($results);
         }

--- a/src/Jobs/Stages/PullFromSource.php
+++ b/src/Jobs/Stages/PullFromSource.php
@@ -27,7 +27,7 @@ final class PullFromSource
     public function handle(): void
     {
         $results = $this->source->get()->filter->shouldBeSearchable();
-        if (!$results->isEmpty()) {
+        if (! $results->isEmpty()) {
             // Cache last id
             Cache::put('scout_import_last_id', $results->last()->getKey());
 


### PR DESCRIPTION
Fixed SQL statements getting slower and slower when importing big data。

### Screenshot of importing big data before fixing it

![微信截图_20210201125338](https://user-images.githubusercontent.com/78338803/106421593-f2b94700-6497-11eb-8f77-b1efcc940988.png)
![微信截图_20210201125358](https://user-images.githubusercontent.com/78338803/106421653-09f83480-6498-11eb-8306-df7b0236f8a6.png)
It's almost 20 seconds a SQL statement to the end.Five million data takes more than an hour

### Screenshot of importing big data after fixing it
![微信截图_20210201134442](https://user-images.githubusercontent.com/78338803/106421820-652a2700-6498-11eb-8fa5-edb6bfde767a.png)
![微信截图_20210201134453](https://user-images.githubusercontent.com/78338803/106421825-665b5400-6498-11eb-8ff7-2807195fffe3.png)

A single SQL is 8ms on average.The import completed in a few minutes

In general, rely on the forPageAfterId method.

But the way to save the last ID doesn't feel good enough. You must have a better way to solve it.Here's one way to think about it.