### PR TITLE
fixes overriding scout commands if not config('scout.driver')

### DIFF
--- a/src/ScoutElasticSearchServiceProvider.php
+++ b/src/ScoutElasticSearchServiceProvider.php
@@ -49,10 +49,12 @@ final class ScoutElasticSearchServiceProvider extends ServiceProvider
     private function registerCommands(): void
     {
         if ($this->app->runningInConsole()) {
-            $this->commands([
-                ImportCommand::class,
-                FlushCommand::class,
-            ]);
+            if (config('scout.driver') === 'Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine') {
+                $this->commands([
+                    ImportCommand::class,
+                    FlushCommand::class,
+                ]);
+            }
         }
     }
 }


### PR DESCRIPTION
this will allow switching between multiple drivers based on config('scout.driver')
basically will prevent registering the commands that override the native scout commands - therefore allowing other drivers to be used