### PR TITLE
🚧 Enhancement: Avoid `ambiguous` In Some Cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+## [4.0.10] - 2021-08-01
+### Fixed
+-  Avoid ambiguous In Some Cases
+
+## [4.0.9] - 2021-07-29
+### Fixed
+-  Avoid Conflict Helper Function `resolve()` In Some Packages
+
 ## [4.0.8] - 2021-07-23
 ### Added
 -  whereIn filter support

--- a/src/Searchable/DefaultImportSource.php
+++ b/src/Searchable/DefaultImportSource.php
@@ -80,7 +80,7 @@ final class DefaultImportSource implements ImportSource
             ->when($softDelete, function ($query) {
                 return $query->withTrashed();
             })
-            ->orderBy($this->model()->getKeyName());
+            ->orderBy($this->model()->getQualifiedKeyName());
         $scopes = $this->scopes;
 
         return collect($scopes)->reduce(function ($instance, $scope) {


### PR DESCRIPTION
This will Just Add The Name Of The Table Before Key,
For Example `id` will become `products.id`
See `\Illuminate\Database\Eloquent\Model::qualifyColumn`
![Screen Shot 2021-07-29 at 7 52 20 PM](https://user-images.githubusercontent.com/2941118/127533345-f99bf724-57c5-47d7-9a44-3c5d0b1093d9.png)
