### PR TITLE
elasticsearch 8 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^8.0.12|^8.1",
-        "elasticsearch/elasticsearch": "^7.2",
+        "elasticsearch/elasticsearch": "^8.0",
+        "handcraftedinthealps/elasticsearch-dsl": "^8.0",
         "laravel/scout": "^8.0|^9.0",
-        "ongr/elasticsearch-dsl": "^7.0",
         "roave/better-reflection": "^4.3|^5.0"
     },
     "require-dev": {

--- a/src/Console/Commands/FlushCommand.php
+++ b/src/Console/Commands/FlushCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Matchish\ScoutElasticSearch\Console\Commands;
 
+use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Illuminate\Console\Command;
 use Matchish\ScoutElasticSearch\Searchable\SearchableListFactory;
 

--- a/src/Console/Commands/FlushCommand.php
+++ b/src/Console/Commands/FlushCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Matchish\ScoutElasticSearch\Console\Commands;
 
-use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Illuminate\Console\Command;
 use Matchish\ScoutElasticSearch\Searchable\SearchableListFactory;
 

--- a/src/ElasticSearch/Params/Bulk.php
+++ b/src/ElasticSearch/Params/Bulk.php
@@ -50,7 +50,6 @@ final class Bulk
                     'index' => [
                         '_index' => $model->searchableAs(),
                         '_id' => $scoutKey,
-                        '_type' => '_doc',
                         'routing' => false === empty($routing) ? $routing : $scoutKey,
                     ],
                 ];
@@ -73,7 +72,6 @@ final class Bulk
                     'delete' => [
                         '_index' => $model->searchableAs(),
                         '_id' => $scoutKey,
-                        '_type' => '_doc',
                         'routing' => false === empty($routing) ? $routing : $scoutKey,
                     ],
                 ];

--- a/src/ElasticSearchServiceProvider.php
+++ b/src/ElasticSearchServiceProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Matchish\ScoutElasticSearch;
 
-use Elasticsearch\Client;
-use Elasticsearch\ClientBuilder;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
 use Illuminate\Support\ServiceProvider;
 use Matchish\ScoutElasticSearch\ElasticSearch\Config\Config;
 

--- a/src/Jobs/Import.php
+++ b/src/Jobs/Import.php
@@ -2,7 +2,7 @@
 
 namespace Matchish\ScoutElasticSearch\Jobs;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Illuminate\Bus\Queueable;
 use Illuminate\Support\Collection;
 use Matchish\ScoutElasticSearch\ProgressReportable;

--- a/src/Jobs/Stages/CleanUp.php
+++ b/src/Jobs/Stages/CleanUp.php
@@ -2,8 +2,8 @@
 
 namespace Matchish\ScoutElasticSearch\Jobs\Stages;
 
-use Elasticsearch\Client;
-use Elasticsearch\Common\Exceptions\Missing404Exception;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Alias\Get as GetAliasParams;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Delete as DeleteIndexParams;
 use Matchish\ScoutElasticSearch\Searchable\ImportSource;
@@ -31,9 +31,8 @@ final class CleanUp
         $source = $this->source;
         $params = GetAliasParams::anyIndex($source->searchableAs());
         try {
-            /** @var array $response */
-            $response = $elasticsearch->indices()->getAlias($params->toArray());
-        } catch (Missing404Exception $e) {
+            $response = $elasticsearch->indices()->getAlias($params->toArray())->asArray();
+        } catch (ClientResponseException $e) {
             $response = [];
         }
         foreach ($response as $indexName => $data) {

--- a/src/Jobs/Stages/CreateWriteIndex.php
+++ b/src/Jobs/Stages/CreateWriteIndex.php
@@ -2,7 +2,7 @@
 
 namespace Matchish\ScoutElasticSearch\Jobs\Stages;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Matchish\ScoutElasticSearch\ElasticSearch\DefaultAlias;
 use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Create;

--- a/src/Jobs/Stages/RefreshIndex.php
+++ b/src/Jobs/Stages/RefreshIndex.php
@@ -2,7 +2,7 @@
 
 namespace Matchish\ScoutElasticSearch\Jobs\Stages;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Refresh;
 

--- a/src/Jobs/Stages/SwitchToNewAndRemoveOldIndex.php
+++ b/src/Jobs/Stages/SwitchToNewAndRemoveOldIndex.php
@@ -2,7 +2,7 @@
 
 namespace Matchish\ScoutElasticSearch\Jobs\Stages;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Alias\Get;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Alias\Update;
@@ -36,7 +36,7 @@ final class SwitchToNewAndRemoveOldIndex
     {
         $source = $this->source;
         $params = Get::anyIndex($source->searchableAs());
-        $response = $elasticsearch->indices()->getAlias($params->toArray());
+        $response = $elasticsearch->indices()->getAlias($params->toArray())->asArray();
 
         $params = new Update();
         foreach ($response as $indexName => $alias) {

--- a/src/ScoutElasticSearchServiceProvider.php
+++ b/src/ScoutElasticSearchServiceProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Matchish\ScoutElasticSearch;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\EngineManager;
 use Laravel\Scout\ScoutServiceProvider;

--- a/tests/Feature/ElasticSearchEngineTest.php
+++ b/tests/Feature/ElasticSearchEngineTest.php
@@ -16,15 +16,14 @@ final class ElasticSearchEngineTest extends IntegrationTestCase
         Product::unsetEventDispatcher();
 
         $productsAmount = random_int(1, 5);
-        $products = factory(Product::class, $productsAmount)->states(['iphone'])->create();
+        factory(Product::class, $productsAmount)->states(['iphone'])->create();
         Product::setEventDispatcher($dispatcher);
 
         Artisan::call('scout:import');
 
-        $results = Product::search('Quia', static function($client, $body) {
+        $results = Product::search('Quia', static function ($client, $body) {
             return $client->search(['index' => 'products', 'body' => $body->toArray()]);
         })->raw();
-
         $this->assertEmpty($results['hits']['hits']);
     }
 
@@ -39,7 +38,7 @@ final class ElasticSearchEngineTest extends IntegrationTestCase
 
         Artisan::call('scout:import');
 
-        $results = Product::search('iphone', static function($client, $body) {
+        $results = Product::search('iphone', static function ($client, $body) {
             return $client->search(['index' => 'products', 'body' => $body->toArray()]);
         })->raw();
 

--- a/tests/Feature/ElasticSearchEngineTest.php
+++ b/tests/Feature/ElasticSearchEngineTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Product;
+use Illuminate\Support\Facades\Artisan;
+use Tests\IntegrationTestCase;
+
+final class ElasticSearchEngineTest extends IntegrationTestCase
+{
+    public function test_pass_empty_response(): void
+    {
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        $productsAmount = random_int(1, 5);
+        $products = factory(Product::class, $productsAmount)->states(['iphone'])->create();
+        Product::setEventDispatcher($dispatcher);
+
+        Artisan::call('scout:import');
+
+        $results = Product::search('Quia', static function($client, $body) {
+            return $client->search(['index' => 'products', 'body' => $body->toArray()]);
+        })->raw();
+
+        $this->assertEmpty($results['hits']['hits']);
+    }
+
+    public function test_pass_with_response(): void
+    {
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        $productsAmount = random_int(1, 5);
+        factory(Product::class, $productsAmount)->states(['iphone'])->create();
+        Product::setEventDispatcher($dispatcher);
+
+        Artisan::call('scout:import');
+
+        $results = Product::search('iphone', static function($client, $body) {
+            return $client->search(['index' => 'products', 'body' => $body->toArray()]);
+        })->raw();
+
+        $this->assertNotEmpty($results['hits']['hits']);
+    }
+}

--- a/tests/Feature/FlushCommandTest.php
+++ b/tests/Feature/FlushCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Product;
+use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Illuminate\Support\Facades\Artisan;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Bulk;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Refresh;

--- a/tests/Feature/FlushCommandTest.php
+++ b/tests/Feature/FlushCommandTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Product;
-use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Illuminate\Support\Facades\Artisan;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Bulk;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Indices\Refresh;

--- a/tests/Feature/ImportCommandTest.php
+++ b/tests/Feature/ImportCommandTest.php
@@ -142,7 +142,7 @@ final class ImportCommandTest extends IntegrationTestCase
 
         Artisan::call('scout:import');
 
-        $this->assertFalse($this->elasticsearch->indices()->exists(['index' => 'products_old']), 'Old index must be deleted');
+        $this->assertFalse($this->elasticsearch->indices()->exists(['index' => 'products_old'])->asBool(), 'Old index must be deleted');
     }
 
     public function test_progress_report()

--- a/tests/Feature/ScoutElasticSearchServiceProviderTest.php
+++ b/tests/Feature/ScoutElasticSearchServiceProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace Matchish\ScoutElasticSearch;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Tests\TestCase;
 
 class ScoutElasticSearchServiceProviderTest extends TestCase

--- a/tests/Integration/Jobs/Stages/CleanUpTest.php
+++ b/tests/Integration/Jobs/Stages/CleanUpTest.php
@@ -27,8 +27,8 @@ class CleanUpTest extends IntegrationTestCase
 
         $stage = new CleanUp(DefaultImportSourceFactory::from(Product::class));
         $stage->handle($this->elasticsearch);
-        $writeIndexExist = $this->elasticsearch->indices()->exists(['index' => 'products_new']);
-        $readIndexExist = $this->elasticsearch->indices()->exists(['index' => 'products_old']);
+        $writeIndexExist = $this->elasticsearch->indices()->exists(['index' => 'products_new'])->asBool();
+        $readIndexExist = $this->elasticsearch->indices()->exists(['index' => 'products_old'])->asBool();
 
         $this->assertFalse($writeIndexExist);
         $this->assertTrue($readIndexExist);

--- a/tests/Integration/Jobs/Stages/CreateWriteIndexTest.php
+++ b/tests/Integration/Jobs/Stages/CreateWriteIndexTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Jobs\Stages;
 
 use App\Product;
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Matchish\ScoutElasticSearch\ElasticSearch\Index;
 use Matchish\ScoutElasticSearch\Jobs\Stages\CreateWriteIndex;
 use Matchish\ScoutElasticSearch\Searchable\DefaultImportSourceFactory;
@@ -15,10 +15,11 @@ final class CreateWriteIndexTest extends IntegrationTestCase
 {
     public function test_create_write_index(): void
     {
+        /** @var Client $elasticsearch */
         $elasticsearch = $this->app->make(Client::class);
         $stage = new CreateWriteIndex(DefaultImportSourceFactory::from(Product::class), Index::fromSource(DefaultImportSourceFactory::from(Product::class)));
         $stage->handle($elasticsearch);
-        $response = $elasticsearch->indices()->getAlias(['index' => '*', 'name' => 'products']);
+        $response = $elasticsearch->indices()->getAlias(['index' => '*', 'name' => 'products'])->asArray();
         $this->assertTrue($this->containsWriteIndex($response, 'products'));
     }
 

--- a/tests/Integration/Jobs/Stages/RefreshIndexTest.php
+++ b/tests/Integration/Jobs/Stages/RefreshIndexTest.php
@@ -21,7 +21,6 @@ final class RefreshIndexTest extends IntegrationTestCase
             ['index' => [
                 '_index' => 'products',
                 '_id' => 'id',
-                '_type' => '_doc',
             ]],
             [
                 'id' => 1,
@@ -40,7 +39,7 @@ final class RefreshIndexTest extends IntegrationTestCase
                 ],
             ],
         ];
-        $response = $this->elasticsearch->search($params);
+        $response = $this->elasticsearch->search($params)->asArray();
         $this->assertEquals(1, $response['hits']['total']['value']);
     }
 }

--- a/tests/Integration/Jobs/Stages/SwitchToNewAndRemoveOldIndexTest.php
+++ b/tests/Integration/Jobs/Stages/SwitchToNewAndRemoveOldIndexTest.php
@@ -27,9 +27,9 @@ final class SwitchToNewAndRemoveOldIndexTest extends IntegrationTestCase
         $stage = new SwitchToNewAndRemoveOldIndex(DefaultImportSourceFactory::from(Product::class), new Index('products_new'));
         $stage->handle($this->elasticsearch);
 
-        $newIndexExist = $this->elasticsearch->indices()->exists(['index' => 'products_new']);
-        $oldIndexExist = $this->elasticsearch->indices()->exists(['index' => 'products_old']);
-        $alias = $this->elasticsearch->indices()->getAlias(['index' => 'products_new']);
+        $newIndexExist = $this->elasticsearch->indices()->exists(['index' => 'products_new'])->asBool();
+        $oldIndexExist = $this->elasticsearch->indices()->exists(['index' => 'products_old'])->asBool();
+        $alias = $this->elasticsearch->indices()->getAlias(['index' => 'products_new'])->asArray();
 
         $this->assertTrue($newIndexExist);
         $this->assertFalse($oldIndexExist);

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 
 /**
  * Class IntegrationTestCase.

--- a/tests/Unit/ElasticSearch/Params/BulkTest.php
+++ b/tests/Unit/ElasticSearch/Params/BulkTest.php
@@ -17,7 +17,7 @@ class BulkTest extends TestCase
         $params = $bulk->toArray();
 
         $this->assertEquals([
-            'body' => [['delete' => ['_index' => 'products', '_type' => '_doc', '_id' => 2, 'routing' => 2]]],
+            'body' => [['delete' => ['_index' => 'products', '_id' => 2, 'routing' => 2]]],
         ], $params);
     }
 
@@ -31,7 +31,7 @@ class BulkTest extends TestCase
         $params = $bulk->toArray();
 
         $this->assertEquals([
-            'body' => [['delete' => ['_index' => 'products', '_type' => '_doc', '_id' => 'Scout', 'routing' => 'Scout']]],
+            'body' => [['delete' => ['_index' => 'products', '_id' => 'Scout', 'routing' => 'Scout']]],
         ], $params);
     }
 
@@ -45,7 +45,7 @@ class BulkTest extends TestCase
 
         $this->assertEquals([
             'body' => [
-                ['index' => ['_index' => 'products', '_type' => '_doc', '_id' => 2, 'routing' => 2]],
+                ['index' => ['_index' => 'products', '_id' => 2, 'routing' => 2]],
                 ['title' => 'Scout', 'id' => 2, '__class_name' => 'App\Product'],
             ],
         ], $params);
@@ -62,7 +62,7 @@ class BulkTest extends TestCase
 
         $this->assertEquals([
             'body' => [
-                ['index' => ['_index' => 'products', '_type' => '_doc', '_id' => 'Scout', 'routing' => 'Scout']],
+                ['index' => ['_index' => 'products', '_id' => 'Scout', 'routing' => 'Scout']],
                 ['title' => 'Scout', 'id' => 2, '__class_name' => 'App\Product'],
             ],
         ], $params);
@@ -78,7 +78,7 @@ class BulkTest extends TestCase
         $params = $bulk->toArray();
         $this->assertEquals([
             'body' => [
-                ['index' => ['_index' => 'products', '_type' => '_doc', '_id' => 2, 'routing' => 2]],
+                ['index' => ['_index' => 'products', '_id' => 2, 'routing' => 2]],
                 ['title' => 'Scout', '__soft_deleted' => 0, 'id' => 2, '__class_name' => 'App\Product'],
             ],
         ], $params);

--- a/tests/Unit/Engines/ElasticSearchEngineTest.php
+++ b/tests/Unit/Engines/ElasticSearchEngineTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit\Engines;
 
 use App\Product;
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Laravel\Scout\Builder;
 use Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine;
 use Mockery as m;

--- a/tests/Unit/Engines/ElasticSearchEngineTest.php
+++ b/tests/Unit/Engines/ElasticSearchEngineTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Engines;
 
 use App\Product;
 use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
 use Laravel\Scout\Builder;
 use Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine;
 use Mockery as m;
@@ -17,30 +18,6 @@ class ElasticSearchEngineTest extends TestCase
         $ids = $sut->mapIds(['hits' => ['hits' => [['_id' => 1], ['_id' => 15]]]]);
 
         $this->assertEquals([1, 15], $ids->all());
-    }
-
-    public function test_pass_client_to_callback()
-    {
-        $client = m::mock(Client::class);
-        $engine = new ElasticSearchEngine($client);
-        $query = 'zonda';
-        $client->shouldReceive('search')->once()->withNoArgs();
-        $builder = new Builder(new Product(), $query, function ($client, $query) {
-            return $client->search();
-        });
-        $engine->search($builder);
-    }
-
-    public function test_pass_search_builder_to_callback()
-    {
-        $client = m::mock(Client::class);
-        $engine = new ElasticSearchEngine($client);
-        $client->shouldReceive('search')->once()->with(m::type('array'));
-        $query = 'zonda';
-        $builder = new Builder(new Product(), $query, function ($client, $query) {
-            return $client->search($query->toArray());
-        });
-        $engine->search($builder);
     }
 
     public function test_pass_query_to_callback_before_executing()

--- a/tests/Unit/Engines/ElasticSearchEngineTest.php
+++ b/tests/Unit/Engines/ElasticSearchEngineTest.php
@@ -4,10 +4,8 @@ namespace Tests\Unit\Engines;
 
 use App\Product;
 use Elastic\Elasticsearch\Client;
-use Elastic\Elasticsearch\ClientBuilder;
 use Laravel\Scout\Builder;
 use Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine;
-use Mockery as m;
 use Tests\TestCase;
 
 class ElasticSearchEngineTest extends TestCase


### PR DESCRIPTION
`Elastic\Elasticsearch\Client` client is Final with `elasticsearch-php:8.0.x`. So we could not use mocking for that class. We need to mock the `ElasticSearchEngine` class and count the `search` method of this function on the `test_pass_client_to_callback` and `test_pass_search_builder_to_callback` tests. Not finished yet. 