### PR TITLE
changelog update for elasticsearch version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+## [6.0.0] - 2022-04-30
+### Added
+- Elasticsearch 8 Support
+
 ## [5.0.2] - 2022-03-24
 ### Added
 -  multiple ElasticSearch nodes support

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ Don't forget to :star: the package if you like it. :pray:
 - PHP version >= 8.0
 - Laravel Framework version >= 8.0.0
 
-| Elasticsearch version | ElasticsearchDSL version    |
-| --------------------- | --------------------------- |
-| >= 7.0                | >= 3.0.0                    |
-| >= 6.0, < 7.0         | < 3.0.0                     |
+| Elasticsearch version | ElasticsearchDSL version |
+|-----------------------|--------------------------|
+| >= 8.0                | >= 8.0.0                 |
+| >= 7.0                | >= 3.0.0                 |
+| >= 6.0, < 7.0         | < 3.0.0                  |
 
 ## :rocket: Installation
 


### PR DESCRIPTION
I think we need to bump the version to 6, right? With this version, the `_type` will be removed and some aggregation types will change, and there won't be any backward compatibility. But also, we had already bumped the version to 5.x for PHP 8. So, I could not decide which version we need to choose.