### PR TITLE
Upgrade versions of docker-compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       XDEBUG_CONFIG: ${XDEBUG_CONFIG}
       PHP_IDE_CONFIG: ${PHP_IDE_CONFIG}
       ELASTICSEARCH_HOST: ${ELASTICSEARCH_HOST}
+      ELASTICSEARCH_USER: ${ELASTICSEARCH_USER}
+      ELASTICSEARCH_PASSWORD: ${ELASTICSEARCH_PASSWORD}
       DB_HOST: ${DB_HOST}
       DB_DATABASE: ${DB_DATABASE}
       DB_USERNAME: ${DB_USERNAME}
@@ -42,6 +44,7 @@ services:
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
     environment:
+      - ELASTIC_PASSWORD=${ELASTICSEARCH_PASSWORD}
       - discovery.type=single-node
       - cluster.routing.allocation.disk.threshold_enabled=false
       - bootstrap.memory_lock=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     networks:
       - default
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.1.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.3
     user: "1000:1000"
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - discovery.type=single-node
       - cluster.routing.allocation.disk.threshold_enabled=false
       - bootstrap.memory_lock=true
+      - action.destructive_requires_name=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/docker-library/php/blob/master/7.1/fpm/Dockerfile
-FROM php:7.3-fpm as php
+FROM php:8.1-fpm as php
 ARG TIMEZONE
 
 MAINTAINER Shliakhov Sergey <shlyakhov.up@gmail.com>

--- a/tests/Feature/ScoutElasticSearchServiceProviderTest.php
+++ b/tests/Feature/ScoutElasticSearchServiceProviderTest.php
@@ -57,6 +57,7 @@ class ScoutElasticSearchServiceProviderTest extends TestCase
     {
         $this->app['config']->set('elasticsearch.cloud_id', 'Test:ZXUtY2VudHJhbC0xLmF3cy5jbG91ZC5lcy5pbyQ0ZGU0NmNlZDhkOGQ0NTk2OTZlNTQ0ZmU1ZjMyYjk5OSRlY2I0YTJlZmY0OTA0ZDliOTE5NzMzMmQwOWNjOTY5Ng==');
         $this->app['config']->set('elasticsearch.api_key', '123456');
+        $this->app['config']->set('elasticsearch.user', null);
         $provider = new ElasticSearchServiceProvider($this->app);
         $this->assertEquals([Client::class], $provider->provides());
         /** @var Client $client */


### PR DESCRIPTION
Currently, `composer.json` requires `php 8` and `elasticsearch 8.0`, this PR bumps versions of `elasticsearch` and `php`.

### Changes summary:
- Bump elasticsearch version to 8.1.3.
- Bump PHP base image to `php:8.1-fpm`.
- Add elasticsearch required auth parameters from env.
- Set correct elasticsearch parameters for tests to pass.