### PR TITLE
v5: use handcraftedinthealps/elasticsearch-dsl instead of ongr/elasticsearch-dsl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0.12|^8.1",
         "elasticsearch/elasticsearch": "^7.2",
         "laravel/scout": "^8.0|^9.0",
-        "ongr/elasticsearch-dsl": "^7.0",
+        "handcraftedinthealps/elasticsearch-dsl": "^7.0",
         "roave/better-reflection": "^4.3|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
#236

handcraftedinthealps/elasticsearch-dsl supports symfony 6, which is required for laravel 10.