### PR TITLE
Convert `ElasticSearchEngine->performSearch` result to array when the…

### DIFF
--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -197,7 +197,7 @@ final class ElasticSearchEngine extends Engine
                 $callback,
                 $this->elasticsearch,
                 $searchBody
-            );
+            )->asArray();
         }
 
         $model = $builder->model;


### PR DESCRIPTION
fixes #250 

…re is callback passed (so it's the same when no callback is passed)

I have tried to set up the docker image with `make install` as per CONTRIBUTING.md, but I got some error about not supported architecture (I'm on M2 processor). If not too much trouble, could I ask you to perform the tests? 

Either-way I have manually tested this update on my local app, and it works as I think it should be, so unless this breaks something else, everything should be ok.