### PR TITLE
Feature: Add the makeAllSearchableUsing API to the default import source

### DIFF
--- a/src/Searchable/DefaultImportSource.php
+++ b/src/Searchable/DefaultImportSource.php
@@ -9,7 +9,7 @@ use Matchish\ScoutElasticSearch\Database\Scopes\PageScope;
 
 final class DefaultImportSource implements ImportSource
 {
-    public const DEFAULT_CHUNK_SIZE = 500;
+    const DEFAULT_CHUNK_SIZE = 500;
 
     /**
      * @var string
@@ -70,7 +70,7 @@ final class DefaultImportSource implements ImportSource
      */
     private function model()
     {
-        return new $this->className();
+        return new $this->className;
     }
 
     private function newQuery(): Builder

--- a/src/Searchable/DefaultImportSource.php
+++ b/src/Searchable/DefaultImportSource.php
@@ -75,12 +75,9 @@ final class DefaultImportSource implements ImportSource
 
     private function newQuery(): Builder
     {
-        $query = $this->model()->newQuery();
+        $query = $this->className::makeAllSearchableUsing($this->model()->newQuery());
         $softDelete = $this->className::usesSoftDelete() && config('scout.soft_delete', false);
         $query
-            ->when(true, function ($query) {
-                return $this->className::makeAllSearchableUsing($query);
-            })
             ->when($softDelete, function ($query) {
                 return $query->withTrashed();
             })

--- a/src/Searchable/DefaultImportSource.php
+++ b/src/Searchable/DefaultImportSource.php
@@ -9,7 +9,7 @@ use Matchish\ScoutElasticSearch\Database\Scopes\PageScope;
 
 final class DefaultImportSource implements ImportSource
 {
-    const DEFAULT_CHUNK_SIZE = 500;
+    public const DEFAULT_CHUNK_SIZE = 500;
 
     /**
      * @var string
@@ -70,7 +70,7 @@ final class DefaultImportSource implements ImportSource
      */
     private function model()
     {
-        return new $this->className;
+        return new $this->className();
     }
 
     private function newQuery(): Builder
@@ -78,6 +78,9 @@ final class DefaultImportSource implements ImportSource
         $query = $this->model()->newQuery();
         $softDelete = $this->className::usesSoftDelete() && config('scout.soft_delete', false);
         $query
+            ->when(true, function ($query) {
+                $this->className::makeAllSearchableUsing($query);
+            })
             ->when($softDelete, function ($query) {
                 return $query->withTrashed();
             })

--- a/src/Searchable/DefaultImportSource.php
+++ b/src/Searchable/DefaultImportSource.php
@@ -79,7 +79,7 @@ final class DefaultImportSource implements ImportSource
         $softDelete = $this->className::usesSoftDelete() && config('scout.soft_delete', false);
         $query
             ->when(true, function ($query) {
-                $this->className::makeAllSearchableUsing($query);
+                return $this->className::makeAllSearchableUsing($query);
             })
             ->when($softDelete, function ($query) {
                 return $query->withTrashed();

--- a/tests/Feature/ImportCommandTest.php
+++ b/tests/Feature/ImportCommandTest.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Book;
-use App\Post;
-use stdClass;
-use App\Product;
 use App\BookWithCustomKey;
-use Tests\IntegrationTestCase;
-use Illuminate\Support\Facades\Bus;
+use App\Post;
+use App\Product;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Bus;
 use Matchish\ScoutElasticSearch\Jobs\Import;
 use Matchish\ScoutElasticSearch\Jobs\QueueableJob;
+use stdClass;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\IntegrationTestCase;
 
 final class ImportCommandTest extends IntegrationTestCase
 {

--- a/tests/Unit/Searchable/SearchableListFactoryTest.php
+++ b/tests/Unit/Searchable/SearchableListFactoryTest.php
@@ -18,8 +18,8 @@ class SearchableListFactoryTest extends TestCase
 
         $searchable = $factory->make();
 
-        // There are 4 searchable models: Book, BookWithCustomKey, Product and Ticket
-        $this->assertCount(4, $searchable);
+        // There are 5 searchable models: Book, BookWithCustomKey, Product, Ticket and Post
+        $this->assertCount(5, $searchable);
     }
 
     public function test_find_searchable_trait_within_trait()

--- a/tests/laravel/app/Post.php
+++ b/tests/laravel/app/Post.php
@@ -3,7 +3,6 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Searchable;
 
 class Post extends Model

--- a/tests/laravel/app/Post.php
+++ b/tests/laravel/app/Post.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Laravel\Scout\Searchable;
+
+class Post extends Model
+{
+    use Searchable;
+
+    protected function makeAllSearchableUsing($query)
+    {
+        return $query->where('status', 'published');
+    }
+}

--- a/tests/laravel/database/factories/PostFactory.php
+++ b/tests/laravel/database/factories/PostFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Post;
+use Faker\Generator as Faker;
+
+$factory->define(Post::class, function (Faker $faker) {
+    return [
+        'title' => $faker->text,
+        'body' => $faker->text,
+        'status' => 'draft',
+        'date' => $faker->date(),
+    ];
+});
+
+$factory->state(Post::class, 'draft', function () {
+    return [
+        'status' => 'draft',
+    ];
+});
+
+$factory->state(Post::class, 'published', function () {
+    return [
+        'status' => 'published',
+    ];
+});

--- a/tests/laravel/database/migrations/2019_15_02_000002_create_post_table.php
+++ b/tests/laravel/database/migrations/2019_15_02_000002_create_post_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+final class CreatePostTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('body');
+            $table->string('status');
+            $table->dateTime('date');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+}


### PR DESCRIPTION
In this PR I'm adding the handle of the method `makeAllSearchableUsing` in the `DefaultImportSource`to allow/match this to the scout docs.

https://laravel.com/docs/10.x/scout#modifying-the-import-query

I did this because I found a case where I needed to use the `makeAllSearchableUsing` method in a Model and found this was the easiest way to do it.