### PR TITLE
Add ssl verify config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ MixedSearch::search('title:Barcelona or to:Barcelona')
 In this example you will get collection of `Ticket` and `Book` models where ticket's arrival city or
 book title is `Barcelona`
 
+### SSL Verification
+You can disable SSL verification by setting the following in your env
+```
+ELASTICSEARCH_SSL_VERIFICATION=false
+```
+
 ### Working with results
 Often your response isn't collection of models but aggregations or models with higlights an so on.
 In this case you need to implement your own implementation of `HitsIteratorAggregate` and bind it in your service provider

--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -6,6 +6,7 @@ return [
     'password' => env('ELASTICSEARCH_PASSWORD'),
     'cloud_id' => env('ELASTICSEARCH_CLOUD_ID'),
     'api_key' => env('ELASTICSEARCH_API_KEY'),
+    'ssl_verification' => env('ELASTICSEARCH_SSL_VERIFICATION', true),
     'queue' => [
         'timeout' => env('SCOUT_QUEUE_TIMEOUT'),
     ],

--- a/src/ElasticSearch/Config/Config.php
+++ b/src/ElasticSearch/Config/Config.php
@@ -6,6 +6,7 @@ namespace Matchish\ScoutElasticSearch\ElasticSearch\Config;
  * @method static array hosts()
  * @method static user()
  * @method static password()
+ * @method static sslVerification()
  * @method static elasticCloudId()
  * @method static apiKey()
  * @method static queueTimeout()

--- a/src/ElasticSearch/Config/Storage.php
+++ b/src/ElasticSearch/Config/Storage.php
@@ -52,7 +52,7 @@ class Storage
      */
     public function sslVerification(): bool
     {
-        return (bool)$this->loadConfig('ssl_verification') ?? true;
+        return (bool) $this->loadConfig('ssl_verification') ?? true;
     }
 
     /**

--- a/src/ElasticSearch/Config/Storage.php
+++ b/src/ElasticSearch/Config/Storage.php
@@ -48,6 +48,14 @@ class Storage
     }
 
     /**
+     * @return bool
+     */
+    public function sslVerification(): bool
+    {
+        return (bool)$this->loadConfig('ssl_verification') ?? false;
+    }
+
+    /**
      * @return ?string
      */
     public function elasticCloudId(): ?string

--- a/src/ElasticSearch/Config/Storage.php
+++ b/src/ElasticSearch/Config/Storage.php
@@ -52,7 +52,7 @@ class Storage
      */
     public function sslVerification(): bool
     {
-        return (bool)$this->loadConfig('ssl_verification') ?? false;
+        return (bool)$this->loadConfig('ssl_verification') ?? true;
     }
 
     /**

--- a/src/ElasticSearchServiceProvider.php
+++ b/src/ElasticSearchServiceProvider.php
@@ -20,8 +20,12 @@ final class ElasticSearchServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/elasticsearch.php', 'elasticsearch');
 
+        $this->app->bind(ClientBuilder::class, function () {
+            return ClientBuilder::create();
+        });
+
         $this->app->bind(Client::class, function () {
-            $clientBuilder = ClientBuilder::create()->setHosts(Config::hosts());
+            $clientBuilder = $this->app->make(ClientBuilder::class)->setHosts(Config::hosts());
             if ($user = Config::user()) {
                 $clientBuilder->setBasicAuthentication($user, Config::password());
             }
@@ -57,6 +61,6 @@ final class ElasticSearchServiceProvider extends ServiceProvider
      */
     public function provides(): array
     {
-        return [Client::class];
+        return [Client::class, ClientBuilder::class];
     }
 }

--- a/src/ElasticSearchServiceProvider.php
+++ b/src/ElasticSearchServiceProvider.php
@@ -26,6 +26,8 @@ final class ElasticSearchServiceProvider extends ServiceProvider
                 $clientBuilder->setBasicAuthentication($user, Config::password());
             }
 
+            $clientBuilder->setSSLVerification(Config::sslVerification());
+
             if ($cloudId = Config::elasticCloudId()) {
                 $clientBuilder->setElasticCloudId($cloudId)
                     ->setApiKey(Config::apiKey());

--- a/tests/Feature/ScoutElasticSearchServiceProviderTest.php
+++ b/tests/Feature/ScoutElasticSearchServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Matchish\ScoutElasticSearch;
 
 use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
 use Elastic\Transport\Exception\NoNodeAvailableException;
 use Tests\TestCase;
 
@@ -64,5 +65,17 @@ class ScoutElasticSearchServiceProviderTest extends TestCase
         $client = $this->app[Client::class];
         $this->assertEquals('ApiKey 123456', $client->getTransport()->getHeaders()['Authorization']);
         $this->assertEquals('4de46ced8d8d459696e544fe5f32b999.eu-central-1.aws.cloud.es.io', $client->getTransport()->getNodePool()->nextNode()->getUri()->getHost());
+    }
+
+    public function test_config_with_ssl_verification_disabled(): void
+    {
+        $this->app['config']->set('elasticsearch.ssl_verification', false);
+        $mock = $this->createPartialMock(ClientBuilder::class, 'setSSLVerification');
+        $mock
+            ->expects($this->once())
+            ->method('setSSLVerification')
+            ->with(false);
+        $this->app->instance(ClientBuilder::class, $mock);
+        $provider = new ElasticSearchServiceProvider($this->app);
     }
 }

--- a/tests/Unit/ElasticSearch/Config/ConfigTest.php
+++ b/tests/Unit/ElasticSearch/Config/ConfigTest.php
@@ -45,4 +45,17 @@ class ConfigTest extends TestCase
         $this->assertEquals('cloud-id', $config::elasticCloudId());
         $this->assertEquals('123456', $config::apiKey());
     }
+
+    public function test_ssl_verification_unset_defaults_false(): void
+    {
+        $config = new ScoutConfig();
+        $this->assertEquals(false, $config::sslVerification());
+    }
+
+    public function test_ssl_verification_enables(): void
+    {
+        Config::set('elasticsearch.ssl_verification', true);
+        $config = new ScoutConfig();
+        $this->assertEquals(true, $config::sslVerification());
+    }
 }

--- a/tests/Unit/ElasticSearch/Config/ConfigTest.php
+++ b/tests/Unit/ElasticSearch/Config/ConfigTest.php
@@ -46,16 +46,16 @@ class ConfigTest extends TestCase
         $this->assertEquals('123456', $config::apiKey());
     }
 
-    public function test_ssl_verification_unset_defaults_false(): void
+    public function test_ssl_verification_unset_defaults_true(): void
     {
-        $config = new ScoutConfig();
-        $this->assertEquals(false, $config::sslVerification());
-    }
-
-    public function test_ssl_verification_enables(): void
-    {
-        Config::set('elasticsearch.ssl_verification', true);
         $config = new ScoutConfig();
         $this->assertEquals(true, $config::sslVerification());
+    }
+
+    public function test_ssl_verification_can_be_disabled(): void
+    {
+        Config::set('elasticsearch.ssl_verification', false);
+        $config = new ScoutConfig();
+        $this->assertEquals(false, $config::sslVerification());
     }
 }


### PR DESCRIPTION
This adds the ability to disable SSL Verification using the environment variable: `ELASTICSEARCH_SSL_VERIFICATION=false`

# Notes

When trying to test that the SSL verification is actually disabled correctly, I couldn't really compare against the following as it's all private:
```
dd($client->getTransport()->getClient());
Symfony\Component\HttpClient\Psr18Client^ {#8779
  -client: Symfony\Component\HttpClient\CurlHttpClient^ {#8771
    -defaultOptions: array:31 [
      "verify_host" => false
      "verify_peer" => false
```

I ended up needing to add the ClientBuilder to be loaded by the container so that I can verify the sslVerification method is being called correctly using mocks