### PR TITLE
Add possibility to use instances of classes that implement ONGR\ElasticsearchDSL\BuilderInterface as values for where() in Laravel Scout query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,32 @@ $results = Product::search('zonga', function(\Elastic\Elasticsearch\Client $clie
 > Otherwise, the `HitsIteratorAggregate` class will throw an error. You can check the issue 
 > [here](https://github.com/matchish/laravel-scout-elasticsearch/issues/215).
 
+### Conditions ###
+
+Scout supports only 3 conditions: `->where(column, value)` (strict equation), `->whereIn(column, array)` and `->whereNotIn(column, array)`: 
+
+```php
+Product::search('(title:this OR description:this) AND (title:that OR description:that)')
+    ->where('price', 100)
+    ->whereIn('type', ['used', 'like new'])
+    ->whereNotIn('type', ['new', 'refurbished']);
+```
+
+Scout does not support any operators, but you can pass ElasticSearch terms like `RangeQuery` as value to `->where()`:
+
+```php
+
+use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
+
+Product::search('(title:this OR description:this) AND (title:that OR description:that)')
+    ->where('price', new RangeQuery('price', [
+        RangeQuery::GTE => 100,
+        RangeQuery::LTE => 1000,
+    ]);
+```
+
+Full list of ElasticSearch terms is in `vendor/handcraftedinthealps/elasticsearch-dsl/src/Query/TermLevel`.
+
 ### Search amongst multiple models
 You can do it with `MixedSearch` class, just pass indices names separated by commas to the `within` method.
 ```php

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -3,6 +3,7 @@
 namespace Matchish\ScoutElasticSearch\ElasticSearch;
 
 use Laravel\Scout\Builder;
+use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\FullText\QueryStringQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
@@ -63,7 +64,10 @@ final class SearchFactory
     {
         if (static::hasWheres($builder)) {
             foreach ($builder->wheres as $field => $value) {
-                $boolQuery->add(new TermQuery((string) $field, $value), BoolQuery::FILTER);
+                if (!($value instanceof BuilderInterface)) {
+                    $value = new TermQuery((string) $field, $value);
+                }
+                $boolQuery->add($value, BoolQuery::FILTER);
             }
         }
 

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -64,7 +64,7 @@ final class SearchFactory
     {
         if (static::hasWheres($builder)) {
             foreach ($builder->wheres as $field => $value) {
-                if (!($value instanceof BuilderInterface)) {
+                if (! ($value instanceof BuilderInterface)) {
                     $value = new TermQuery((string) $field, $value);
                 }
                 $boolQuery->add($value, BoolQuery::FILTER);

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -51,7 +51,7 @@ final class SearchTest extends IntegrationTestCase
         $iphonePromoUsedAndLikeNewWithRange = Product::search('iphone')
             ->where('price', new RangeQuery('price', [
                 RangeQuery::GTE => 100,
-                RangeQuery::LTE => 100
+                RangeQuery::LTE => 100,
             ]))
             ->whereIn('type', ['used', 'like new'])
             ->get();

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -11,6 +11,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\LazyCollection;
 use Matchish\ScoutElasticSearch\MixedSearch;
+use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
 use Tests\IntegrationTestCase;
 
 final class SearchTest extends IntegrationTestCase
@@ -46,6 +47,17 @@ final class SearchTest extends IntegrationTestCase
 
         $this->assertEquals($iphonePromoUsedAndLikeNew->count(), $iphonePromoUsedAndLikeNewAmount);
         $this->assertInstanceOf(Product::class, $iphonePromoUsedAndLikeNew->first());
+
+        $iphonePromoUsedAndLikeNewWithRange = Product::search('iphone')
+            ->where('price', new RangeQuery('price', [
+                RangeQuery::GTE => 100,
+                RangeQuery::LTE => 100
+            ]))
+            ->whereIn('type', ['used', 'like new'])
+            ->get();
+
+        $this->assertEquals($iphonePromoUsedAndLikeNewWithRange->count(), $iphonePromoUsedAndLikeNewAmount);
+        $this->assertInstanceOf(Product::class, $iphonePromoUsedAndLikeNewWithRange->first());
     }
 
     public function test_sorted_paginate(): void


### PR DESCRIPTION
For https://github.com/matchish/laravel-scout-elasticsearch/issues/259