### PR TITLE
Fix query_string issue and range search issue

### DIFF
--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -26,7 +26,9 @@ final class SearchFactory
             $boolQuery = new BoolQuery();
             $boolQuery = static::addWheres($builder, $boolQuery);
             $boolQuery = static::addWhereIns($builder, $boolQuery);
-            $boolQuery->add($query, BoolQuery::MUST);
+            if ($builder->query) {
+                $boolQuery->add($query, BoolQuery::MUST);
+            }
             $search->addQuery($boolQuery);
         } else {
             $search->addQuery($query);
@@ -64,10 +66,11 @@ final class SearchFactory
     {
         if (static::hasWheres($builder)) {
             foreach ($builder->wheres as $field => $value) {
-                if (! ($value instanceof BuilderInterface)) {
-                    $value = new TermQuery((string) $field, $value);
+                if ($value instanceof BuilderInterface) {
+                    $boolQuery->add($value, BoolQuery::FILTER);
+                } else {
+                    $boolQuery->add(new TermsQuery((string) $field, $value), BoolQuery::FILTER);
                 }
-                $boolQuery->add($value, BoolQuery::FILTER);
             }
         }
 


### PR DESCRIPTION
When i call like this
```php
Product::search()
    ->where('price', new RangeQuery('price', [
        RangeQuery::GTE => 900,
    ]))
```
search body will be:
```
GET /_search
{
  "query": {
    "bool": {
      "filter": [
        {
          "term": {
            "price": {
              "range": {
                "gte": 500,
                "lte": 1000
              }
            }
          }
        }
      ],
      "must": [
        {
          "query_string": {
            "default_field": "name",
            "query": ""
          }
        }
      ]
    }
  }
}
```

This is not what i want. Please check if the PR work for you.