### PR TITLE
[feat] change extend method name to elasticsearch

### DIFF
--- a/src/ScoutElasticSearchServiceProvider.php
+++ b/src/ScoutElasticSearchServiceProvider.php
@@ -23,7 +23,7 @@ final class ScoutElasticSearchServiceProvider extends ServiceProvider
     {
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'scout');
 
-        $this->app->make(EngineManager::class)->extend(ElasticSearchEngine::class, function () {
+        $this->app->make(EngineManager::class)->extend('elasticsearch', function () {
             $elasticsearch = app(Client::class);
 
             return new ElasticSearchEngine($elasticsearch);


### PR DESCRIPTION
This PR changes the extended name to simply "elasticsearch". So, in the environment, instead of:
`SCOUT_DRIVER=Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine`
we can simply write:
`SCOUT_DRIVER=elasticsearch`
