### PR TITLE
Adaptive import

### DIFF
--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -8,6 +8,7 @@ return [
     'api_key' => env('ELASTICSEARCH_API_KEY'),
     'queue' => [
         'timeout' => env('SCOUT_QUEUE_TIMEOUT'),
+        'name' => env('SCOUT_QUEUE_NAME'),
     ],
     'indices' => [
         'mappings' => [

--- a/src/Jobs/Import.php
+++ b/src/Jobs/Import.php
@@ -25,6 +25,10 @@ final class Import
      * @var bool
      */
     public $parallel = false;
+    /**
+     * @var bool
+     */
+    public $adaptive = false;
 
     public ?int $timeout = null;
 
@@ -69,6 +73,6 @@ final class Import
      */
     private function stages(): Collection
     {
-        return ImportStages::fromSource($this->source, $this->parallel);
+        return ImportStages::fromSource($this->source, $this->parallel, $this->adaptive);
     }
 }

--- a/src/Jobs/Stages/PullFromSourceParallel.php
+++ b/src/Jobs/Stages/PullFromSourceParallel.php
@@ -20,6 +20,11 @@ final class PullFromSourceParallel implements StageInterface
     const DEFAULT_HANDLER_COUNT = 1;
 
     /**
+     * @var string
+     */
+    const DEFAULT_QUEUE_NAME = 'indexing-queue';
+
+    /**
      * @var ImportSource
      */
     private $source;
@@ -42,9 +47,7 @@ final class PullFromSourceParallel implements StageInterface
     /**
      * @var array<string>
      */
-    private $queues = [
-        'import_1',
-    ];
+    private $queues = [];
 
     /**
      * @param  ImportSource  $source
@@ -52,9 +55,11 @@ final class PullFromSourceParallel implements StageInterface
     public function __construct(ImportSource $source)
     {
         $this->source = $source;
-        $this->queues = collect(config('scout.chunk.handlers', self::DEFAULT_HANDLER_COUNT))->map(function ($i) {
-            return 'import_'.$i;
-        })->toArray();
+        $this->queues = [];
+
+        foreach (range(1, config('scout.chunk.handlers', self::DEFAULT_HANDLER_COUNT)) as $i) {
+            $this->queues[] = config('elasticsearch.queue.name', self::DEFAULT_QUEUE_NAME) . '-' . $i;
+        }
     }
 
     /**
@@ -95,7 +100,7 @@ final class PullFromSourceParallel implements StageInterface
             })->pluck('id')->toArray();
         }
 
-        if (count($this->dispatchedJobIds) >= $this->source->getTotalChunks()) {
+        if (count($this->handledJobs) + count($this->dispatchedJobIds) > $this->source->getTotalChunks()) {
             return;
         }
 

--- a/src/Traits/ElasticParams.php
+++ b/src/Traits/ElasticParams.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Matchish\ScoutElasticSearch\Traits;
+
+trait ElasticParams
+{
+    /**
+     * @var float|null
+     */
+    private ?float $_score = null;
+
+    /**
+     * @var array<string, array|string>|null
+     */
+    private ?array $_highlight = null;
+
+    /**
+     * Set elasticsearch score.
+     * 
+     * @param float $score
+     * @return void
+     */
+    public function setElasticsearchScore(float $score): void
+    {
+        $this->_score = $score;
+    }
+
+    /**
+     * Get elasticsearch score.
+     * 
+     * @return float|null
+     */
+    public function getElasticsearchScore(): ?float
+    {
+        return $this->_score;
+    }
+
+    /**
+     * Set elasticsearch highlighting.
+     * 
+     * @param array<string, array|string>
+     * @return void
+     */
+    public function setElasticsearchHighlight(array $highlight): void
+    {
+        $this->_highlight = $highlight;
+    }
+
+    /**
+     * Get elasticsearch highlighting.
+     * 
+     * @return array<string, array|string>|null
+     */
+    public function getElasticsearchHighlight(): ?array
+    {
+        return $this->_highlight;
+    }
+}

--- a/tests/Feature/ImportCommandTest.php
+++ b/tests/Feature/ImportCommandTest.php
@@ -149,6 +149,32 @@ final class ImportCommandTest extends IntegrationTestCase
         $this->assertEquals($productsAmount, $response['hits']['total']['value']);
     }
 
+    public function test_import_all_pages_using_adaptive(): void
+    {
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        $productsAmount = 10;
+
+        factory(Product::class, $productsAmount)->create();
+
+        Product::setEventDispatcher($dispatcher);
+
+        Artisan::call('scout:import', [
+            '--adaptive' => true,
+        ]);
+        $params = [
+            'index' => (new Product())->searchableAs(),
+            'body' => [
+                'query' => [
+                    'match_all' => new stdClass(),
+                ],
+            ],
+        ];
+        $response = $this->elasticsearch->search($params);
+        $this->assertEquals($productsAmount, $response['hits']['total']['value']);
+    }
+
     public function test_import_with_custom_key_all_pages(): void
     {
         $this->app['config']['scout.key'] = 'title';

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -11,6 +11,9 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\LazyCollection;
 use Matchish\ScoutElasticSearch\MixedSearch;
+use ONGR\ElasticsearchDSL\Highlight\Highlight;
+use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\FullText\MatchQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
 use Tests\IntegrationTestCase;
 
@@ -47,6 +50,44 @@ final class SearchTest extends IntegrationTestCase
 
         $this->assertEquals($iphonePromoUsedAndLikeNew->count(), $iphonePromoUsedAndLikeNewAmount);
         $this->assertInstanceOf(Product::class, $iphonePromoUsedAndLikeNew->first());
+    }
+
+    public function test_search_appends_extra_params(): void
+    {
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        $productAmount = rand(5, 10);
+
+        $products = factory(Product::class, $productAmount)->states(['iphone', 'cheap'])->create();
+
+        Product::setEventDispatcher($dispatcher);
+
+        Artisan::call('scout:import');
+
+        $search = Product::search('*', function($client, $body) {
+            $body->addQuery(new MatchQuery('title', 'IPhone'), BoolQuery::SHOULD);
+
+            $highlight = new Highlight();
+            $highlight->addField('title');
+            $body->addHighlight($highlight);
+
+            $elasticResponse = $client->search([
+                'index' => (new Product())->searchableAs(),
+                'body' => $body->toArray(),
+            ]);
+
+            return $elasticResponse->asArray();
+        })->get();
+
+        /** @var Product $item */
+        $item = $search->random();
+        
+        $this->assertEquals($search->count(), $productAmount);
+        $this->assertNotNull($item->getElasticsearchScore());
+        $this->assertNotNull($item->getElasticsearchHighlight());
+        $this->assertTrue($item->save());
+        $this->assertInstanceOf(Product::class, $item->first());
     }
 
     public function test_search_with_custom_filter()

--- a/tests/laravel/app/Product.php
+++ b/tests/laravel/app/Product.php
@@ -5,10 +5,11 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Searchable;
+use Matchish\ScoutElasticSearch\Traits\ElasticParams;
 
 class Product extends Model
 {
-    use Searchable, SoftDeletes;
+    use Searchable, SoftDeletes, ElasticParams;
 
     protected $fillable = [
         'title',


### PR DESCRIPTION
Based on some performance testing ([here](https://docs.google.com/spreadsheets/d/1xbnlBdGV-vtQ8Jh3crR7HKzttPXywzTsQKJoiSRUHRI/edit?usp=sharing)), I have added an 'adaptive' import option. That will check if parallel import is 'worth it' in that case.

Useful when having multiple imports going, with varying document count.
This is still a work in progress, would like your opinion if this is even something that should be added, or should just be kept under the same '--parallel' option.

Things to do:
Check Queue::size of the parallel-import queues, if they are full or currently handling another import - disable parallel import.
More performance testing, as the number of documents where parallel import is faster than regular could vary.