### PR TITLE
Adaptive import option

### DIFF
--- a/src/Jobs/Import.php
+++ b/src/Jobs/Import.php
@@ -25,6 +25,10 @@ final class Import
      * @var bool
      */
     public $parallel = false;
+    /**
+     * @var bool
+     */
+    public $adaptive = false;
 
     public ?int $timeout = null;
 
@@ -69,6 +73,6 @@ final class Import
      */
     private function stages(): Collection
     {
-        return ImportStages::fromSource($this->source, $this->parallel);
+        return ImportStages::fromSource($this->source, $this->parallel, $this->adaptive);
     }
 }

--- a/tests/Feature/ImportCommandTest.php
+++ b/tests/Feature/ImportCommandTest.php
@@ -149,6 +149,32 @@ final class ImportCommandTest extends IntegrationTestCase
         $this->assertEquals($productsAmount, $response['hits']['total']['value']);
     }
 
+    public function test_import_all_pages_using_adaptive(): void
+    {
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        $productsAmount = 10;
+
+        factory(Product::class, $productsAmount)->create();
+
+        Product::setEventDispatcher($dispatcher);
+
+        Artisan::call('scout:import', [
+            '--adaptive' => true,
+        ]);
+        $params = [
+            'index' => (new Product())->searchableAs(),
+            'body' => [
+                'query' => [
+                    'match_all' => new stdClass(),
+                ],
+            ],
+        ];
+        $response = $this->elasticsearch->search($params);
+        $this->assertEquals($productsAmount, $response['hits']['total']['value']);
+    }
+
     public function test_import_with_custom_key_all_pages(): void
     {
         $this->app['config']['scout.key'] = 'title';


### PR DESCRIPTION
Based on some performance testing ([here](https://docs.google.com/spreadsheets/d/1xbnlBdGV-vtQ8Jh3crR7HKzttPXywzTsQKJoiSRUHRI/edit?usp=sharing)), I have added an 'adaptive' import option. That will check if parallel import is 'worth it' in that case.

Useful when having multiple imports going, with varying document count.
This is still a work in progress, would like your opinion if this is even something that should be added, or should just be kept under the same '--parallel' option.

Things to do:
Check Queue::size of the parallel-import queues, if they are full or currently handling another import - disable parallel import.
More performance testing, as the number of documents where parallel import is faster than regular could vary.