### PR TITLE
Change if conditions order in soft deletes check for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+## [7.6.2] - 2024-06-24
+### Fixed
+- [Change if conditions order in soft deletes check for compatibility](https://github.com/matchish/laravel-scout-elasticsearch/pull/282).
+
 ## [7.6.1] - 2024-05-14
 ### Fixed
 - fix for [parser incompatibility](https://github.com/matchish/laravel-scout-elasticsearch/issues/273)

--- a/src/ElasticSearch/Params/Bulk.php
+++ b/src/ElasticSearch/Params/Bulk.php
@@ -41,7 +41,7 @@ final class Bulk
         $payload = ['body' => []];
         $payload = collect($this->indexDocs)->reduce(
             function ($payload, $model) {
-                if ($model::usesSoftDelete() && config('scout.soft_delete', false)) {
+                if (config('scout.soft_delete', false) && $model::usesSoftDelete()) {
                     $model->pushSoftDeleteMetadata();
                 }
 


### PR DESCRIPTION
I am integrating this package with Flarum, which is based on Laravel, but not everything is the same. E.g. models do not have the `usesSoftDelete` method, which causes errors. A simple swap of the order of the checks solves this problem.
Context: https://github.com/clarkwinkelmann/flarum-ext-scout/pull/3#issuecomment-2184266623

This should not change the behavior of this package, and it will help in my case.