### PR TITLE
Add config option to disable SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Set env variables
 SCOUT_DRIVER=Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine
 ```
 
-The package uses `\ElasticSearch\Client` from official package, but does not try to configure it, 
-so feel free do it in your app service provider. 
+The package uses `\ElasticSearch\Client` from official package, but does not try to configure it 
+beyond connection configuration, so feel free do it in your app service provider. 
 But if you don't want to do it right now, 
 you can use `Matchish\ElasticSearchServiceProvider` from the package.  
 Register the provider, adding to `config/app.php`
@@ -87,6 +87,12 @@ or use commas as separator for additional nodes
 ```
 ELASTICSEARCH_HOST=host:port,host:port
 ```
+
+You can disable SSL verification by setting the following in your env
+```
+ELASTICSEARCH_SSL_VERIFICATION=false
+```
+
 And publish config example for elasticsearch  
 `php artisan vendor:publish --tag config`
 

--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -6,6 +6,7 @@ return [
     'password' => env('ELASTICSEARCH_PASSWORD'),
     'cloud_id' => env('ELASTICSEARCH_CLOUD_ID'),
     'api_key' => env('ELASTICSEARCH_API_KEY'),
+    'ssl_verification' => env('ELASTICSEARCH_SSL_VERIFICATION', true),
     'queue' => [
         'timeout' => env('SCOUT_QUEUE_TIMEOUT'),
     ],

--- a/src/ElasticSearch/Config/Config.php
+++ b/src/ElasticSearch/Config/Config.php
@@ -8,6 +8,7 @@ namespace Matchish\ScoutElasticSearch\ElasticSearch\Config;
  * @method static password()
  * @method static elasticCloudId()
  * @method static apiKey()
+ * @method static sslVerification()
  * @method static queueTimeout()
  */
 class Config

--- a/src/ElasticSearch/Config/Storage.php
+++ b/src/ElasticSearch/Config/Storage.php
@@ -64,6 +64,14 @@ class Storage
     }
 
     /**
+     * @return bool
+     */
+    public function sslVerification(): bool
+    {
+        return (bool) ($this->loadConfig('ssl_verification') ?? true);
+    }
+
+    /**
      * @return ?int
      */
     public function queueTimeout(): ?int

--- a/src/ElasticSearchServiceProvider.php
+++ b/src/ElasticSearchServiceProvider.php
@@ -21,7 +21,9 @@ final class ElasticSearchServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/elasticsearch.php', 'elasticsearch');
 
         $this->app->bind(Client::class, function () {
-            $clientBuilder = ClientBuilder::create()->setHosts(Config::hosts());
+            $clientBuilder = ClientBuilder::create()
+                ->setHosts(Config::hosts())
+                ->setSSLVerification(Config::sslVerification());
             if ($user = Config::user()) {
                 $clientBuilder->setBasicAuthentication($user, Config::password());
             }


### PR DESCRIPTION
Based on #255 by [danielsimkus](https://github.com/danielsimkus)

Adds a config option to disable SSL verification on server connection.

.env
`ELASTICSEARCH_SSL_VERIFICATION=false`