### PR TITLE
Fix for using pagination with custom query in Scout Builder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
+
+## [7.9.0] - 2024-11-14
 ### Fixed
 - [Using pagination with custom query in Scout Builder](https://github.com/matchish/laravel-scout-elasticsearch/pull/290).
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
+### Fixed
+- [Using pagination with custom query in Scout Builder](https://github.com/matchish/laravel-scout-elasticsearch/pull/290).
+### Added
+- [Using `options()` of a builder](https://github.com/matchish/laravel-scout-elasticsearch/issues/252) for set `from` parameter.
+- Supporting `take()` method of builder for setting response `size`.
 
 ## [7.8.0] - 2024-06-24
 ### Added
-- [Added supports of whereNotIn condition]([https://github.com/matchish/laravel-scout-elasticsearch/pull/282](https://github.com/matchish/laravel-scout-elasticsearch/pull/286).
-- 
+- [Added supports of whereNotIn condition](https://github.com/matchish/laravel-scout-elasticsearch/pull/282).
+
 ## [7.6.2] - 2024-06-24
 ### Fixed
 - [Change if conditions order in soft deletes check for compatibility](https://github.com/matchish/laravel-scout-elasticsearch/pull/282).

--- a/README.md
+++ b/README.md
@@ -276,6 +276,25 @@ Product::search()
 
 Full list of ElasticSearch terms is in `vendor/handcraftedinthealps/elasticsearch-dsl/src/Query/TermLevel`.
 
+### Pagination
+The engine supports [Elasticsearch pagination](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html)
+with [Scout Builder pagination](https://laravel.com/docs/11.x/scout#pagination) or by setting page sizes 
+and offsets using the `->take($size)` method and `->options(['from' => $from])`.
+
+> Caution : Builder pagination takes precedence over the `take()` and `options()` setting.
+
+For example:
+
+```php
+Product::search()
+    ->take(20)
+    ->options([
+        'from' => 20,
+    ])
+    ->paginate(50);
+```
+This will return the first 50 results, ignoring the specified offset.
+
 ### Search amongst multiple models
 You can do it with `MixedSearch` class, just pass indices names separated by commas to the `within` method.
 ```php

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -34,6 +34,9 @@ final class SearchFactory
         } else {
             $search->addQuery($query);
         }
+        if (isset($builder->limit)) {
+            $search->setSize($builder->limit);
+        }
         if (array_key_exists('from', $options)) {
             $search->setFrom($options['from']);
         }

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -2,6 +2,7 @@
 
 namespace Matchish\ScoutElasticSearch\ElasticSearch;
 
+use Illuminate\Support\Arr;
 use Laravel\Scout\Builder;
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
@@ -15,11 +16,12 @@ final class SearchFactory
 {
     /**
      * @param  Builder  $builder
-     * @param  array  $options
+     * @param  array  $enforceOptions
      * @return Search
      */
-    public static function create(Builder $builder, array $options = []): Search
+    public static function create(Builder $builder, array $enforceOptions = []): Search
     {
+        $options = static::prepareOptions($builder, $enforceOptions);
         $search = new Search();
         $query = new QueryStringQuery($builder->query);
         if (static::hasWhereFilters($builder)) {
@@ -33,9 +35,6 @@ final class SearchFactory
             $search->addQuery($boolQuery);
         } else {
             $search->addQuery($query);
-        }
-        if (isset($builder->limit)) {
-            $search->setSize($builder->limit);
         }
         if (array_key_exists('from', $options)) {
             $search->setFrom($options['from']);
@@ -137,5 +136,23 @@ final class SearchFactory
     private static function hasWhereNotIns($builder): bool
     {
         return isset($builder->whereNotIns) && ! empty($builder->whereNotIns);
+    }
+
+    private static function prepareOptions(Builder $builder, array $enforceOptions = []): array
+    {
+        $options = [];
+
+        if (isset($builder->limit)) {
+            $options['size'] = $builder->limit;
+        }
+
+        return array_merge($options, self::supportedOptions($builder), $enforceOptions);
+    }
+
+    private static function supportedOptions(Builder $builder): array
+    {
+        return Arr::only($builder->options, [
+            'from',
+        ]);
     }
 }

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -183,7 +183,7 @@ final class ElasticSearchEngine extends Engine
 
     /**
      * @param  BaseBuilder  $builder
-     * @param  array  $options
+     * @param array $options
      * @return SearchResults|mixed
      */
     private function performSearch(BaseBuilder $builder, $options = [])

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -183,7 +183,7 @@ final class ElasticSearchEngine extends Engine
 
     /**
      * @param  BaseBuilder  $builder
-     * @param array $options
+     * @param  array  $options
      * @return SearchResults|mixed
      */
     private function performSearch(BaseBuilder $builder, $options = [])

--- a/tests/Unit/ElasticSearch/SearchFactoryTest.php
+++ b/tests/Unit/ElasticSearch/SearchFactoryTest.php
@@ -14,11 +14,11 @@ class SearchFactoryTest extends TestCase
     public function test_limit_set_in_builder(): void
     {
         $builder = new Builder(new Product(), '*');
-        $builder->take($size = 50);
+        $builder->take($expectedSize = 50);
 
         $search = SearchFactory::create($builder);
 
-        $this->assertEquals($search->getSize(), $size);
+        $this->assertEquals($expectedSize, $search->getSize());
     }
 
     public function test_limit_compatible_with_pagination(): void
@@ -28,9 +28,51 @@ class SearchFactoryTest extends TestCase
 
         $search = SearchFactory::create($builder, [
             'from' => 0,
-            'size' => $size = 50,
+            'size' => $expectedSize = 50,
         ]);
 
-        $this->assertEquals($search->getSize(), $size);
+        $this->assertEquals($expectedSize, $search->getSize());
+    }
+
+    public function test_size_set_in_options_dont_take_effect(): void
+    {
+        $builder = new Builder(new Product(), '*');
+        $builder->take($expectedSize = 30)
+            ->options([
+                'size' => 100,
+            ]);
+
+        $search = SearchFactory::create($builder);
+
+        $this->assertEquals($expectedSize, $search->getSize());
+    }
+
+    public function test_from_set_in_options_take_effect(): void
+    {
+        $builder = new Builder(new Product(), '*');
+        $builder->options([
+            'from' => $expectedFrom = 100,
+        ]);
+
+        $search = SearchFactory::create($builder);
+
+        $this->assertEquals($expectedFrom, $search->getFrom());
+    }
+
+    public function test_both_parameters_dont_take_effect_on_pagination(): void
+    {
+        $builder = new Builder(new Product(), '*');
+        $builder->options([
+            'from' => 250,
+        ])
+            ->take(30);
+
+        $search = SearchFactory::create($builder, [
+            'from' => $expectedFrom = 100,
+            'size' => $expectedSize = 50,
+        ]);
+
+        $this->assertEquals($expectedSize, $search->getSize());
+        $this->assertEquals($expectedFrom, $search->getFrom());
     }
 }

--- a/tests/Unit/ElasticSearch/SearchFactoryTest.php
+++ b/tests/Unit/ElasticSearch/SearchFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\ElasticSearch;
+
+use App\Product;
+use Laravel\Scout\Builder;
+use Matchish\ScoutElasticSearch\ElasticSearch\SearchFactory;
+use Tests\TestCase;
+
+class SearchFactoryTest extends TestCase
+{
+    public function test_limit_set_in_builder(): void
+    {
+        $builder = new Builder(new Product(), '*');
+        $builder->take($size = 50);
+
+        $search = SearchFactory::create($builder);
+
+        $this->assertEquals($search->getSize(), $size);
+    }
+
+    public function test_limit_compatible_with_pagination(): void
+    {
+        $builder = new Builder(new Product(), '*');
+        $builder->take(30);
+
+        $search = SearchFactory::create($builder, [
+            'from' => 0,
+            'size' => $size = 50,
+        ]);
+
+        $this->assertEquals($search->getSize(), $size);
+    }
+}


### PR DESCRIPTION
### Problem
When calling the paginate method on `Laravel\Scout\Builder`, the `getTotalCount` method is triggered.
```php
    public function paginate($perPage = null, $pageName = 'page', $page = null)
    {
        // method implementation

        return Container::getInstance()->makeWith(LengthAwarePaginator::class, [
            'items' => $results,
            'total' => $this->getTotalCount($results), // Calculates the total count of results
            'perPage' => $perPage,
            'currentPage' => $page,
            'options' => [
                'path' => Paginator::resolveCurrentPath(),
                'pageName' => $pageName,
            ],
        ])->appends('query', $this->query);
    }
```
The `getTotalCount` method retrieves the total count of results from the search engine. It includes a check for a query callback, which may trigger an additional database query if specified.
```php
    protected function getTotalCount($results)
    {
        $engine = $this->engine();

        $totalCount = $engine->getTotalCount($results);

        // Checks if a query callback is defined, which could result in an additional database query.
        if (is_null($this->queryCallback)) {
            return $totalCount;
        }

        $ids = $engine->mapIdsFrom($results, $this->model->getScoutKeyName())->all();

        if (count($ids) < $totalCount) {
            $ids = $engine->keys(tap(clone $this, function ($builder) use ($totalCount) {
                // Problem: Setting `Builder::$limit` here does not affect the actual query.
                // Attempts to set a limit for the query based on the total count or the existing limit.
                $builder->take(
                    is_null($this->limit) ? $totalCount : min($this->limit, $totalCount)
                );
            }))->all();
        }

        return $this->model->queryScoutModelsByIds(
            $this, $ids
        )->toBase()->getCountForPagination();
    }
```
Additionally, the default `take` method on `Laravel\Scout\Builder` does not allow setting a response size limit in this implementation.

### Proposed Fix

In the `SearchFactory::create` method, add a check for the presence of the `$builder->limit` parameter before examining the `$options` parameter. This adjustment preserves compatibility with the pagination implementation by ensuring that any explicitly set limit in $builder is prioritized.

This change will allow the pagination functionality to respect a custom limit if defined, while maintaining backward compatibility with existing configurations.