### PR TITLE
Allow setting source (fields) from options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
+### Added
+- Use [`source` in options](https://github.com/matchish/laravel-scout-elasticsearch/pull/293) to set returned fields
 
 ## [7.9.0] - 2024-11-14
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -276,6 +276,10 @@ Product::search()
 
 Full list of ElasticSearch terms is in `vendor/handcraftedinthealps/elasticsearch-dsl/src/Query/TermLevel`.
 
+### Limiting returned fields
+Sometimes your indexed models have fields that should not appear in returned result.
+You can set returned fields in `source` option `->options(['source' => ['this', 'that', 'something', 'else']])` 
+
 ### Pagination
 The engine supports [Elasticsearch pagination](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html)
 with [Scout Builder pagination](https://laravel.com/docs/11.x/scout#pagination) or by setting page sizes 
@@ -309,7 +313,7 @@ In this example you will get collection of `Ticket` and `Book` models where tick
 book title is `Barcelona`
 
 ### Working with results
-Often your response isn't collection of models but aggregations or models with higlights an so on.
+Often your response isn't collection of models but aggregations or models with higlights and so on.
 In this case you need to implement your own implementation of `HitsIteratorAggregate` and bind it in your service provider
 
 [Here is a case](https://github.com/matchish/laravel-scout-elasticsearch/issues/28)

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -42,6 +42,9 @@ final class SearchFactory
         if (array_key_exists('size', $options)) {
             $search->setSize($options['size']);
         }
+        if (array_key_exists('source', $options)) {
+            $search->setSource($options['source']);
+        }
         if (! empty($builder->orders)) {
             foreach ($builder->orders as $order) {
                 $search->addSort(new FieldSort($order['column'], $order['direction']));
@@ -153,6 +156,7 @@ final class SearchFactory
     {
         return Arr::only($builder->options, [
             'from',
+            'source',
         ]);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends BaseTestCase
 
         $this->withFactories(database_path('factories'));
 
-        Artisan::call('migrate:fresh', ['--database' => 'mysql']);
+        Artisan::call('migrate:fresh', ['--database' => env('DB_CONNECTION', 'mysql')]);
     }
 
     /**

--- a/tests/Unit/ElasticSearch/SearchFactoryTest.php
+++ b/tests/Unit/ElasticSearch/SearchFactoryTest.php
@@ -75,4 +75,16 @@ class SearchFactoryTest extends TestCase
         $this->assertEquals($expectedSize, $search->getSize());
         $this->assertEquals($expectedFrom, $search->getFrom());
     }
+
+    public function test_source_can_be_set_from_options(): void
+    {
+        $builder = new Builder(new Product(), '*');
+        $builder->options([
+            'source' => $expectedFields = ['title', 'price'],
+        ]);
+
+        $search = SearchFactory::create($builder);
+
+        $this->assertEquals($expectedFields, $search->isSource());
+    }
 }


### PR DESCRIPTION
In case you want to limit returned fields.

Use case: search index has added custom fields that are searched but should not be returned in results