### PR TITLE
Do not add empty query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
-
+- FIX: SearchFactory adds empty `query_string` query even if query string is empty when no `where` clauses are set.  
 
 ## [7.10.0] - 2024-12-128
 ### Added

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -23,18 +23,17 @@ final class SearchFactory
     {
         $options = static::prepareOptions($builder, $enforceOptions);
         $search = new Search();
-        $query = new QueryStringQuery($builder->query);
         if (static::hasWhereFilters($builder)) {
             $boolQuery = new BoolQuery();
             $boolQuery = static::addWheres($builder, $boolQuery);
             $boolQuery = static::addWhereIns($builder, $boolQuery);
             $boolQuery = static::addWhereNotIns($builder, $boolQuery);
             if (! empty($builder->query)) {
-                $boolQuery->add($query, BoolQuery::MUST);
+                $boolQuery->add(new QueryStringQuery($builder->query));
             }
             $search->addQuery($boolQuery);
-        } else {
-            $search->addQuery($query);
+        } elseif (! empty($builder->query)) {
+            $search->addQuery(new QueryStringQuery($builder->query));
         }
         if (array_key_exists('from', $options)) {
             $search->setFrom($options['from']);


### PR DESCRIPTION
If there are no `where` clauses then `SearchFactory` adds query string filter even if query string is empty