### PR TITLE
Need to specify type to make it compatibility with Laravel IDE Helper.

### DIFF
--- a/src/ElasticSearch/EloquentHitsIteratorAggregate.php
+++ b/src/ElasticSearch/EloquentHitsIteratorAggregate.php
@@ -41,7 +41,7 @@ final class EloquentHitsIteratorAggregate implements IteratorAggregate
      *
      * @since 5.0.0
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $hits = collect();
         if ($this->results['hits']['total']) {

--- a/src/ElasticSearch/HitsIteratorAggregate.php
+++ b/src/ElasticSearch/HitsIteratorAggregate.php
@@ -6,5 +6,5 @@ interface HitsIteratorAggregate extends \IteratorAggregate
 {
     public function __construct(array $results, callable $callback = null);
 
-    public function getIterator();
+    public function getIterator(): \Traversable;
 }


### PR DESCRIPTION
When using IDE Helper for Laravel meta info generation command, there is a problem with this package. 

````
@php artisan ide-helper:meta --ansi
[05-Feb-2025 14:12:24 UTC] PHP Fatal error:  During inheritance of IteratorAggregate: Uncaught ReflectionException: Class 'env' not found. in /var/www/vendor/barryvdh/laravel-ide-helper/src/Console/MetaCommand.php:158
Stack trace:
#0 [internal function]: Barryvdh\LaravelIdeHelper\Console\MetaCommand->Barryvdh\LaravelIdeHelper\Console\{closure}('env')
#1 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(1216): is_subclass_of('env', 'Spatie\\LaravelD...')
#2 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(771): Illuminate\Container\Container->fireBeforeResolvingCallbacks('env', Array)
#3 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(961): Illuminate\Container\Container->resolve('env', Array, true)
#4 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(731): Illuminate\Foundation\Application->resolve('env', Array)
#5 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(946): Illuminate\Container\Container->make('env', Array)
#6 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(1454): Illuminate\Foundation\Application->make('env')
#7 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(743): Illuminate\Container\Container->offsetGet('env')
#8 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(122): Illuminate\Foundation\Application->runningUnitTests()
#9 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(88): Illuminate\Foundation\Bootstrap\HandleExceptions->shouldIgnoreDeprecationErrors()
#10 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(71): Illuminate\Foundation\Bootstrap\HandleExceptions->handleDeprecationError('Return type of ...', '/var/www/vendor...', 9, 8192)
#11 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(255): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(8192, 'Return type of ...', '/var/www/vendor...', 9)
#12 /var/www/vendor/matchish/laravel-scout-elasticsearch/src/ElasticSearch/HitsIteratorAggregate.php(5): Illuminate\Foundation\Bootstrap\HandleExceptions->Illuminate\Foundation\Bootstrap\{closure}(8192, 'Return type of ...', '/var/www/vendor...', 9)
#13 /var/www/vendor/composer/ClassLoader.php(576): include('/var/www/vendor...')
#14 /var/www/vendor/composer/ClassLoader.php(427): Composer\Autoload\{closure}('/var/www/vendor...')
#15 [internal function]: Composer\Autoload\ClassLoader->loadClass('Matchish\\ScoutE...')`