### PR TITLE
Use getCountForPagination for query count

### DIFF
--- a/src/Searchable/DefaultImportSource.php
+++ b/src/Searchable/DefaultImportSource.php
@@ -50,7 +50,7 @@ final class DefaultImportSource implements ImportSource
     public function chunked(): Collection
     {
         $query = $this->newQuery();
-        $totalSearchables = $query->count();
+        $totalSearchables = $query->toBase()->getCountForPagination();
         if ($totalSearchables) {
             $chunkSize = (int) config('scout.chunk.searchable', self::DEFAULT_CHUNK_SIZE);
             $totalChunks = (int) ceil($totalSearchables / $chunkSize);

--- a/tests/Integration/Searchable/DefaultImportSourceTest.php
+++ b/tests/Integration/Searchable/DefaultImportSourceTest.php
@@ -27,6 +27,23 @@ class DefaultImportSourceTest extends TestCase
         $products = $source->get();
         $this->assertEquals($iphonePromoUsedAmount, $products->count());
     }
+
+    public function test_chunked_with_complex_scope()
+    {
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        factory(Product::class, 2)->states(['iphone', 'promo', 'used'])->create();
+        factory(Product::class, 3)->states(['kindle', 'promo', 'new'])->create();
+        factory(Product::class, 2)->states(['iphone', 'promo', 'used'])->create();
+
+        Product::setEventDispatcher($dispatcher);
+
+        $source = new DefaultImportSource(Product::class, [new ComplexScopeWithGroupBy()]);
+        $results = $source->chunked();
+
+        $this->assertEquals(7, $results->sum(fn ($chunk) => $chunk->get()->count()));
+    }
 }
 
 class UsedScope implements Scope
@@ -41,5 +58,17 @@ class UsedScope implements Scope
     public function apply(Builder $builder, Model $model)
     {
         $builder->where('type', 'used');
+    }
+}
+
+class ComplexScopeWithGroupBy implements Scope
+{
+    public function apply(Builder $builder, Model $model)
+    {
+        // Just a simple example where we duplicate all products
+        // and de-duplicate them by grouping on the id.
+        $builder
+            ->leftJoin('products as products2', 'products.id', '=', 'products2.id')
+            ->groupBy('products.id');
     }
 }


### PR DESCRIPTION
The count query doesn't always work properly under certain conditions, specifically a query with a `GROUP BY` seems to be the issue.

We can use the `getCountForPagination` function that laravel provides and uses internally for the pagination function. Scout itself actually also uses this function to get the count.