### PR TITLE
Config compatible with the laravel-elasticsearch config

### DIFF
--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -1,10 +1,12 @@
 <?php
 
 return [
-    'host' => env('ELASTICSEARCH_HOST'),
+    'host' => env('ELASTICSEARCH_PORT') && env('ELASTICSEARCH_SCHEME')
+        ? env('ELASTICSEARCH_SCHEME').'//'.env('ELASTICSEARCH_HOST').':'.env('ELASTICSEARCH_PORT')
+        : env('ELASTICSEARCH_HOST'),
     'user' => env('ELASTICSEARCH_USER'),
-    'password' => env('ELASTICSEARCH_PASSWORD'),
-    'cloud_id' => env('ELASTICSEARCH_CLOUD_ID'),
+    'password' => env('ELASTICSEARCH_PASSWORD', env('ELASTICSEARCH_PASS')),
+    'cloud_id' => env('ELASTICSEARCH_CLOUD_ID', env('ELASTICSEARCH_API_ID')),
     'api_key' => env('ELASTICSEARCH_API_KEY'),
     'ssl_verification' => env('ELASTICSEARCH_SSL_VERIFICATION', true),
     'queue' => [


### PR DESCRIPTION
We're currently using https://github.com/mailerlite/laravel-elasticsearch and the config items from: https://github.com/mailerlite/laravel-elasticsearch/blob/main/config/elasticsearch.php#L42 look like:
```
ELASTICSEARCH_HOST
ELASTICSEARCH_PORT
ELASTICSEARCH_SCHEME
ELASTICSEARCH_USER
ELASTICSEARCH_PASS
ELASTICSEARCH_API_ID
ELASTICSEARCH_API_KEY
```
We're migrating to this package where the env variables are slightly different. With this PR both work and no env changes are required. Saving us some time while upgrading projects.