### PR TITLE
Remove requirement on roave/better-reflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "php": "^8.0.12|^8.1",
         "elasticsearch/elasticsearch": "^8.0",
         "handcraftedinthealps/elasticsearch-dsl": "^8.0",
-        "laravel/scout": "^8.0|^9.0|^10.0",
-        "roave/better-reflection": "^4.3|^5.0|^6.18|^6.36"
+        "laravel/scout": "^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0",

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "xdebug.remote_port=9000" >> /usr/local/etc/php/conf.d/docker-php-ext-x
 RUN echo "xdebug.remote_autostart=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 RUN apt-get update && apt-get install -y procps
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y netcat-openbsd
 RUN apt-get update && apt-get install -y net-tools
 
 FROM php as php-testing


### PR DESCRIPTION
The roave/better-reflection library is VERY big, and has no functionality which can't be replaced with a native Laravel function.

Removing roave/better-reflection also removed jetbrains/phpstorm-stubs which is over 10 MB
