### PR TITLE
Added support for Scout v11.1.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0.12|^8.1",
         "elasticsearch/elasticsearch": "^8.0",
         "handcraftedinthealps/elasticsearch-dsl": "^8.0",
-        "laravel/scout": "^8.0|^9.0|^10.0"
+        "laravel/scout": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0",

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -77,16 +77,16 @@ final class SearchFactory
                 }
 
                 if (isset($where['value']) && $where['value'] instanceof BuilderInterface) {
+                    if ($where['operator'] === '!=') {
+                        $boolQuery->add($where['value'], BoolQuery::MUST_NOT);
+                        continue;
+                    }
                     $where = $where['value'];
                 }
 
                 if (! ($where instanceof BuilderInterface) && isset($where['field'])) {
                     // Post v11.1.0 scout
                     $operator = $where['operator'];
-                    if ($where['operator'] === '!=') {
-                        $boolQuery->add(new TermQuery((string) $field, $where['value']), BoolQuery::MUST_NOT);
-                        continue;
-                    }
 
                     $where = match ($operator) {
                         '=', '!=' => new TermQuery((string) $field, $where['value']),

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -89,10 +89,10 @@ final class SearchFactory
                     }
 
                     $where = match ($operator) {
-                        '=', '!='  => new TermQuery((string) $field, $where['value']),
-                        '>'  => new RangeQuery((string) $field, [RangeQuery::GT => $where['value']]),
+                        '=', '!=' => new TermQuery((string) $field, $where['value']),
+                        '>' => new RangeQuery((string) $field, [RangeQuery::GT => $where['value']]),
                         '>=' => new RangeQuery((string) $field, [RangeQuery::GTE => $where['value']]),
-                        '<'  => new RangeQuery((string) $field, [RangeQuery::LT => $where['value']]),
+                        '<' => new RangeQuery((string) $field, [RangeQuery::LT => $where['value']]),
                         '<=' => new RangeQuery((string) $field, [RangeQuery::LTE => $where['value']]),
                         default => $where
                     };

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -7,6 +7,7 @@ use Laravel\Scout\Builder;
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\FullText\QueryStringQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermsQuery;
 use ONGR\ElasticsearchDSL\Search;
@@ -70,11 +71,42 @@ final class SearchFactory
     private static function addWheres($builder, $boolQuery): BoolQuery
     {
         if (static::hasWheres($builder)) {
-            foreach ($builder->wheres as $field => $value) {
-                if (! ($value instanceof BuilderInterface)) {
-                    $value = new TermQuery((string) $field, $value);
+            foreach ($builder->wheres as $field => $where) {
+                if (isset($where['field'])) {
+                    $field = $where['field'];
                 }
-                $boolQuery->add($value, BoolQuery::FILTER);
+
+                if (isset($where['value']) && $where['value'] instanceof BuilderInterface) {
+                    $where = $where['value'];
+                }
+
+                if (! ($where instanceof BuilderInterface) && isset($where['field'])) {
+                    // Post v11.1.0 scout
+                    $operator = $where['operator'];
+                    if ($where['operator'] === '!=') {
+                        $boolQuery->add(new TermQuery((string) $field, $where['value']), BoolQuery::MUST_NOT);
+                        continue;
+                    }
+
+                    $where = match ($operator) {
+                        '=', '!='  => new TermQuery((string) $field, $where['value']),
+                        '>'  => new RangeQuery((string) $field, [RangeQuery::GT => $where['value']]),
+                        '>=' => new RangeQuery((string) $field, [RangeQuery::GTE => $where['value']]),
+                        '<'  => new RangeQuery((string) $field, [RangeQuery::LT => $where['value']]),
+                        '<=' => new RangeQuery((string) $field, [RangeQuery::LTE => $where['value']]),
+                        default => $where
+                    };
+
+                    if ($operator === '!=') {
+                        $boolQuery->add($where, BoolQuery::MUST_NOT);
+                        continue;
+                    }
+                }
+
+                if (! ($where instanceof BuilderInterface)) {
+                    $where = new TermQuery((string) $field, $where);
+                }
+                $boolQuery->add($where, BoolQuery::FILTER);
             }
         }
 

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -72,11 +72,11 @@ final class SearchFactory
     {
         if (static::hasWheres($builder)) {
             foreach ($builder->wheres as $field => $where) {
-                if (isset($where['field'])) {
+                if (is_array($where) && isset($where['field'])) {
                     $field = $where['field'];
                 }
 
-                if (isset($where['value']) && $where['value'] instanceof BuilderInterface) {
+                if (is_array($where) && isset($where['value']) && $where['value'] instanceof BuilderInterface) {
                     if ($where['operator'] === '!=') {
                         $boolQuery->add($where['value'], BoolQuery::MUST_NOT);
                         continue;
@@ -84,7 +84,7 @@ final class SearchFactory
                     $where = $where['value'];
                 }
 
-                if (! ($where instanceof BuilderInterface) && isset($where['field'])) {
+                if (is_array($where) && isset($where['field'])) {
                     // Post v11.1.0 scout
                     $operator = $where['operator'];
 


### PR DESCRIPTION
See: https://github.com/laravel/scout/commit/d8b1be5021790a9aa97a20622c73a5c7bf2df362#diff-434625111321abb225365806085a3753cb854d098ed9b4b6dc2001235c7f7bc4
Since scout v11.1 the wheres contain an operator and are restructured.