### PR TITLE
Sync master (7.13.0) into 8.x

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -22,13 +22,11 @@ jobs:
                     - php-version: '8.3'
         services:
             elasticsearch:
-                image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1
+                image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
                 ports:
                     - 9200:9200
                 env:
                     discovery.type: 'single-node'
-                    ES_JAVA_OPTS: "-Xms512m -Xmx512m -XX:-UseContainerSupport"
-                    JAVA_OPTS: "-XX:-UseContainerSupport"
                     xpack.security.enabled: 'false'
                 options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=5
             mysql:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -27,6 +27,7 @@ jobs:
                     - 9200:9200
                 env:
                     discovery.type: 'single-node'
+                    ES_JAVA_OPTS: "-Xms512m -Xmx512m -XX:-UseContainerSupport"
                     xpack.security.enabled: 'false'
                 options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=5
             mysql:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -28,6 +28,7 @@ jobs:
                 env:
                     discovery.type: 'single-node'
                     ES_JAVA_OPTS: "-Xms512m -Xmx512m -XX:-UseContainerSupport"
+                    JAVA_OPTS: "-XX:-UseContainerSupport"
                     xpack.security.enabled: 'false'
                 options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=5
             mysql:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
+## [7.13.0] - 2026-05-09
+### Added
+- Support for Laravel Scout v11.1.0+ by updating query where handling for the new Scout where structure and operators. [#322](https://github.com/matchish/laravel-scout-elasticsearch/pull/322)
+
 ## [7.12.0] - 2025-08-26
 ### Changed
 - Removed `roave/better-reflection` dependency and replaced usage with native PHP reflection in `SearchableListFactory`, reducing package size while maintaining behavior. [#314](https://github.com/matchish/laravel-scout-elasticsearch/pull/314)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Don't forget to :star: the package if you like it. :pray:
 - [Search amongst multiple models](#search-amongst-multiple-models)
 - [**Zero downtime** reimport](#zero-downtime-reimport) - it’s a breeze to import data in production.
 - [Eager load relations](#eager-load) - speed up your import.
-- Parallel import to make your import as fast as possible (in [alpha version](https://github.com/matchish/laravel-scout-elasticsearch/releases/tag/8.0.0-alpha.1) for now)
+- Parallel import to make your import as fast as possible (in [alpha version](https://github.com/matchish/laravel-scout-elasticsearch/releases/tag/8.0.0-alpha.3) for now)
 - Import all searchable models at once.
 - A fully configurable mapping for each model.
 - Full power of ElasticSearch in your queries.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0.12|^8.1",
         "elasticsearch/elasticsearch": "^8.0",
         "handcraftedinthealps/elasticsearch-dsl": "^8.0",
-        "laravel/scout": "^8.0|^9.0|^10.0"
+        "laravel/scout": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0",

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -77,16 +77,16 @@ final class SearchFactory
                 }
 
                 if (isset($where['value']) && $where['value'] instanceof BuilderInterface) {
+                    if ($where['operator'] === '!=') {
+                        $boolQuery->add($where['value'], BoolQuery::MUST_NOT);
+                        continue;
+                    }
                     $where = $where['value'];
                 }
 
                 if (! ($where instanceof BuilderInterface) && isset($where['field'])) {
                     // Post v11.1.0 scout
                     $operator = $where['operator'];
-                    if ($where['operator'] === '!=') {
-                        $boolQuery->add(new TermQuery((string) $field, $where['value']), BoolQuery::MUST_NOT);
-                        continue;
-                    }
 
                     $where = match ($operator) {
                         '=', '!=' => new TermQuery((string) $field, $where['value']),

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -89,10 +89,10 @@ final class SearchFactory
                     }
 
                     $where = match ($operator) {
-                        '=', '!='  => new TermQuery((string) $field, $where['value']),
-                        '>'  => new RangeQuery((string) $field, [RangeQuery::GT => $where['value']]),
+                        '=', '!=' => new TermQuery((string) $field, $where['value']),
+                        '>' => new RangeQuery((string) $field, [RangeQuery::GT => $where['value']]),
                         '>=' => new RangeQuery((string) $field, [RangeQuery::GTE => $where['value']]),
-                        '<'  => new RangeQuery((string) $field, [RangeQuery::LT => $where['value']]),
+                        '<' => new RangeQuery((string) $field, [RangeQuery::LT => $where['value']]),
                         '<=' => new RangeQuery((string) $field, [RangeQuery::LTE => $where['value']]),
                         default => $where
                     };

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -7,6 +7,7 @@ use Laravel\Scout\Builder;
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\FullText\QueryStringQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermsQuery;
 use ONGR\ElasticsearchDSL\Search;
@@ -70,11 +71,42 @@ final class SearchFactory
     private static function addWheres($builder, $boolQuery): BoolQuery
     {
         if (static::hasWheres($builder)) {
-            foreach ($builder->wheres as $field => $value) {
-                if (! ($value instanceof BuilderInterface)) {
-                    $value = new TermQuery((string) $field, $value);
+            foreach ($builder->wheres as $field => $where) {
+                if (isset($where['field'])) {
+                    $field = $where['field'];
                 }
-                $boolQuery->add($value, BoolQuery::FILTER);
+
+                if (isset($where['value']) && $where['value'] instanceof BuilderInterface) {
+                    $where = $where['value'];
+                }
+
+                if (! ($where instanceof BuilderInterface) && isset($where['field'])) {
+                    // Post v11.1.0 scout
+                    $operator = $where['operator'];
+                    if ($where['operator'] === '!=') {
+                        $boolQuery->add(new TermQuery((string) $field, $where['value']), BoolQuery::MUST_NOT);
+                        continue;
+                    }
+
+                    $where = match ($operator) {
+                        '=', '!='  => new TermQuery((string) $field, $where['value']),
+                        '>'  => new RangeQuery((string) $field, [RangeQuery::GT => $where['value']]),
+                        '>=' => new RangeQuery((string) $field, [RangeQuery::GTE => $where['value']]),
+                        '<'  => new RangeQuery((string) $field, [RangeQuery::LT => $where['value']]),
+                        '<=' => new RangeQuery((string) $field, [RangeQuery::LTE => $where['value']]),
+                        default => $where
+                    };
+
+                    if ($operator === '!=') {
+                        $boolQuery->add($where, BoolQuery::MUST_NOT);
+                        continue;
+                    }
+                }
+
+                if (! ($where instanceof BuilderInterface)) {
+                    $where = new TermQuery((string) $field, $where);
+                }
+                $boolQuery->add($where, BoolQuery::FILTER);
             }
         }
 

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -88,19 +88,19 @@ final class SearchFactory
                     // Post v11.1.0 scout
                     $operator = $where['operator'];
 
+                    if ($operator === '!=') {
+                        $boolQuery->add(new TermQuery((string) $field, $where['value']), BoolQuery::MUST_NOT);
+                        continue;
+                    }
+
                     $where = match ($operator) {
-                        '=', '!=' => new TermQuery((string) $field, $where['value']),
+                        '=' => new TermQuery((string) $field, $where['value']),
                         '>' => new RangeQuery((string) $field, [RangeQuery::GT => $where['value']]),
                         '>=' => new RangeQuery((string) $field, [RangeQuery::GTE => $where['value']]),
                         '<' => new RangeQuery((string) $field, [RangeQuery::LT => $where['value']]),
                         '<=' => new RangeQuery((string) $field, [RangeQuery::LTE => $where['value']]),
                         default => $where
                     };
-
-                    if ($operator === '!=') {
-                        $boolQuery->add($where, BoolQuery::MUST_NOT);
-                        continue;
-                    }
                 }
 
                 if (! ($where instanceof BuilderInterface)) {

--- a/src/ElasticSearch/SearchFactory.php
+++ b/src/ElasticSearch/SearchFactory.php
@@ -72,11 +72,11 @@ final class SearchFactory
     {
         if (static::hasWheres($builder)) {
             foreach ($builder->wheres as $field => $where) {
-                if (isset($where['field'])) {
+                if (is_array($where) && isset($where['field'])) {
                     $field = $where['field'];
                 }
 
-                if (isset($where['value']) && $where['value'] instanceof BuilderInterface) {
+                if (is_array($where) && isset($where['value']) && $where['value'] instanceof BuilderInterface) {
                     if ($where['operator'] === '!=') {
                         $boolQuery->add($where['value'], BoolQuery::MUST_NOT);
                         continue;
@@ -84,7 +84,7 @@ final class SearchFactory
                     $where = $where['value'];
                 }
 
-                if (! ($where instanceof BuilderInterface) && isset($where['field'])) {
+                if (is_array($where) && isset($where['field'])) {
                     // Post v11.1.0 scout
                     $operator = $where['operator'];
 


### PR DESCRIPTION
## Summary

Brings the `8.x` branch up to date with `master` before the parallel import redesign starts.

- Merges `master` at v7.13.0 (`de088ee`) into `8.x` — 8.x now includes Scout v11.1.0+ `where` handling, the `!=` operator support, and the `where`-array check from [#322](https://github.com/matchish/laravel-scout-elasticsearch/pull/322).
- The only merge conflict was `CHANGELOG.md`, resolved by keeping both sides in semver order (`Unreleased`, `8.0.0-alpha.3`, `7.13.0`, …).
- Follow-up commit fixes the one PHPStan error the merge surfaced in `SearchFactory`: the `!=` operator is now handled before the `match` expression so `BoolQuery::add()` receives a concrete `BuilderInterface` type. No behavior change.

## Testing

- Full PHPUnit suite: **93 tests, all passing** against real Elasticsearch 8.1.3 + MySQL 5.7 (Docker).
- PHPStan: back to the 4 pre-existing errors in `ProcessSearchable`/`PullFromSourceParallel` (confirmed present before this merge; that code is scheduled for removal in the parallel import redesign).

## Merging this PR

⚠️ Use **“Create a merge commit”** — do not squash or rebase. This branch contains the `master` → `8.x` merge commit; squashing would flatten it and the next sync from `master` would re-encounter the same conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)