### PR TITLE
Declare nikic/php-parser and symfony/finder as direct dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
         "php": "^8.0.12|^8.1",
         "elasticsearch/elasticsearch": "^8.0",
         "handcraftedinthealps/elasticsearch-dsl": "^8.0",
-        "laravel/scout": "^8.0|^9.0|^10.0|^11.0"
+        "laravel/scout": "^8.0|^9.0|^10.0|^11.0",
+        "nikic/php-parser": "^5.0",
+        "symfony/finder": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0",


### PR DESCRIPTION
Fixes #273.

## Problem

`SearchableListFactory` uses `nikic/php-parser` and `symfony/finder` directly, but `composer.json` requires neither.

Until 7.11.x, php-parser arrived transitively through `roave/better-reflection`, which requires `nikic/php-parser ^5.0`. Commit 9cd66fa (released as **7.12.0**) removed better-reflection and did not replace that constraint. Nothing else in `require` pulls php-parser in — I checked `laravel/scout`, which depends only on `illuminate/*` and `symfony/console`.

In a typical Laravel app php-parser arrives via `laravel/tinker` → `psy/psysh`, and tinker is a **dev** dependency. So `composer install --no-dev` on a production server can omit it. Then `scout:import` or `scout:flush` without a model argument fails:

```
Error: Class "PhpParser\ParserFactory" not found
```

Both commands hit this path — `ImportCommand.php:41` and `FlushCommand.php:29`.

## Fix

```diff
-        "laravel/scout": "^8.0|^9.0|^10.0|^11.0"
+        "laravel/scout": "^8.0|^9.0|^10.0|^11.0",
+        "nikic/php-parser": "^5.0",
+        "symfony/finder": "^5.4|^6.0|^7.0"
```

**`nikic/php-parser: ^5.0`** — `SearchableListFactory:112` calls `ParserFactory::createForHostVersion()`. php-parser 5 requires PHP >= 7.4 and this package requires PHP >= 8.0.12, so there is no version gap.

### Why `^5.0` and not `^4.18|^5.0`

php-parser backported `createForHostVersion()` to 4.18, so the method itself is not the reason (an earlier revision of this PR claimed it was — that was wrong, verified against a real 4.19.5 install). The reason is how php-parser 4 behaves on modern syntax, tested on 4.19.5:

| Syntax | Result on php-parser 4.19 |
|---|---|
| PHP 8.2 readonly class | parses |
| PHP 8.3 typed class constant | parses |
| PHP 8.4 property hook | `PhpParser\Error` → the file is silently skipped |
| PHP 8.4 `private(set)` | **uncaught `TypeError` inside the Lexer** |

The last case matters most: `getStmts()` catches only `PhpParser\Error`, so one file using asymmetric visibility under `app/` would crash the whole import. With `^5.0` this surfaces at install time instead.

Known trade-off: apps that pin php-parser 4 (psalm 5 pins `^4.17`, psysh 0.11 pins `^4.0`) get a Composer conflict and must update those tools first (psalm 6 and psysh 0.12 both support php-parser 5). Verified with real Composer resolutions.

**`symfony/finder: ^5.4|^6.0|^7.0`** — used in the same class. It is currently present only because `laravel/framework` requires it, which no declared dependency guarantees.

The floor is `^5.4` because Symfony 5.0–5.3 are end of life and were never tested here. laravel/framework requires `symfony/finder ^5.4` from **8.76.2** onward, `^6.0` in Laravel 9–10, and `^7.0` in Laravel 11–12. Earlier Laravel 8 releases require `^5.1`, which overlaps `^5.4` at 5.4 and above, so this creates no conflict.

## Notes

- **No behaviour change.** No source file is touched.
- The original report also asked to refactor away from the removed `create(ParserFactory::PREFER_PHP7)` API. That half was already done in e89cbad (v7.10.0). Only the missing-dependency half was still open.
- `8.x` has the same gap and needs the same change. Tracking separately.
- Worth considering later: Laravel solves this exact problem in `PruneCommand` with Finder plus the PSR-4 path convention and no parser at all. Dropping php-parser is a behaviour change for non-PSR-4 apps, so it belongs in a major release, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

