### PR TITLE
Document how to work with results

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,10 +313,130 @@ In this example you will get collection of `Ticket` and `Book` models where tick
 book title is `Barcelona`
 
 ### Working with results
-Often your response isn't collection of models but aggregations or models with higlights and so on.
-In this case you need to implement your own implementation of `HitsIteratorAggregate` and bind it in your service provider
 
-[Here is a case](https://github.com/matchish/laravel-scout-elasticsearch/issues/28)
+Sometimes you need more than models in the result. For example, the highlighted text or the score of each hit.
+
+The engine builds the result collection with a `HitsIteratorAggregate` taken from the container. You can bind your own class there and put anything you want into the result.
+
+The example below adds highlights to the models.
+
+#### 1. Ask Elasticsearch for highlights
+
+Elasticsearch does not send highlights by default. Add a `Highlight` object to the search body in a callback:
+
+```php
+use ONGR\ElasticsearchDSL\Highlight\Highlight;
+
+$products = Product::search('zonga', function (\Elastic\Elasticsearch\Client $client, $body) {
+    $highlight = new Highlight();
+    $highlight->addField('title');
+    $highlight->addField('description');
+
+    $body->addHighlight($highlight);
+
+    return $client->search([
+        'index' => (new Product)->searchableAs(),
+        'body' => $body->toArray(),
+    ])->asArray();
+})->get();
+```
+
+Now every hit in the response has a `highlight` key. But `->get()` returns only models, so this data is lost. The next step keeps it.
+
+#### 2. Write your own `HitsIteratorAggregate`
+
+```php
+namespace App\Search;
+
+use ArrayIterator;
+use Illuminate\Support\Collection;
+use Laravel\Scout\Builder;
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+
+final class HighlightedHitsIteratorAggregate implements HitsIteratorAggregate
+{
+    private array $results;
+
+    /** @var callable|null */
+    private $callback;
+
+    public function __construct(array $results, ?callable $callback = null)
+    {
+        $this->results = $results;
+        $this->callback = $callback;
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        $hits = $this->results['hits']['hits'] ?? [];
+
+        // MixedSearch can return hits of different classes.
+        // Group them by class and load each group with one query.
+        $models = collect($hits)
+            ->groupBy('_source.__class_name')
+            ->flatMap(function (Collection $classHits, string $class) {
+                $model = new $class;
+                $model->setKeyType('string');
+
+                $builder = new Builder($model, '');
+
+                // Keep the ->query() callback so eager loading still works.
+                if ($this->callback) {
+                    $builder->query($this->callback);
+                }
+
+                return $model->getScoutModelsByIds($builder, $classHits->pluck('_id')->all())
+                    ->keyBy(function ($model) use ($class) {
+                        return $class.'::'.$model->getScoutKey();
+                    });
+            });
+
+        // Sort the models in the same order as the hits
+        // and copy the highlights to each model.
+        $result = collect($hits)->map(function (array $hit) use ($models) {
+            $model = $models->get(($hit['_source']['__class_name'] ?? '').'::'.$hit['_id']);
+
+            // The document is in the index, but the model is not in the database.
+            if ($model === null) {
+                return null;
+            }
+
+            $model->highlight = $hit['highlight'] ?? [];
+
+            return $model;
+        })->filter()->values()->all();
+
+        return new ArrayIterator($result);
+    }
+}
+```
+
+#### 3. Bind the class in a service provider
+
+```php
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+use App\Search\HighlightedHitsIteratorAggregate;
+...
+public function register(): void
+{
+    $this->app->bind(HitsIteratorAggregate::class, HighlightedHitsIteratorAggregate::class);
+}
+```
+
+#### 4. Read the highlights
+
+```php
+foreach ($products as $product) {
+    $product->highlight; // ['title' => ['<em>zonga</em> sneakers']]
+}
+```
+
+#### Good to know
+
+- The engine creates your class with `makeWith(['results' => ..., 'callback' => ...])`. Do not change the constructor signature.
+- `$callback` is the callback from the Scout `->query()` method. Give it to the `Builder`. If you skip this, eager loading with `->query()` no longer works.
+- `$model->highlight = ...` creates a normal model attribute. It appears in `toArray()`, and `save()` tries to write a `highlight` column. To avoid this, declare `public array $highlight = [];` in your model. Then PHP sets a real property, and Eloquent does not see an attribute.
+- Aggregations are in `$this->results['aggregations']`. You can read them in the same class. If you need only the raw response, call `->raw()` instead.
 
 ## :free: License
 Scout ElasticSearch is an open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/tests/Feature/HighlightedResultsTest.php
+++ b/tests/Feature/HighlightedResultsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Library\HighlightedHitsIteratorAggregate;
+use App\Product;
+use Elastic\Elasticsearch\Client;
+use Illuminate\Support\Facades\Artisan;
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+use ONGR\ElasticsearchDSL\Highlight\Highlight;
+use Tests\IntegrationTestCase;
+
+/**
+ * Covers the example in the "Working with results" section of the README.
+ */
+final class HighlightedResultsTest extends IntegrationTestCase
+{
+    public function test_custom_hits_iterator_aggregate_keeps_the_highlights(): void
+    {
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        $zongaAmount = rand(2, 5);
+        factory(Product::class, $zongaAmount)->create(['title' => 'Zonga sneakers']);
+        factory(Product::class, rand(1, 3))->create(['title' => 'Amazon Kindle Fire']);
+
+        Product::setEventDispatcher($dispatcher);
+
+        Artisan::call('scout:import');
+
+        $this->app->bind(HitsIteratorAggregate::class, HighlightedHitsIteratorAggregate::class);
+
+        $products = Product::search('zonga', function (Client $client, $body) {
+            $highlight = new Highlight();
+            $highlight->addField('title');
+
+            $body->addHighlight($highlight);
+
+            return $client->search([
+                'index' => (new Product)->searchableAs(),
+                'body' => $body->toArray(),
+            ])->asArray();
+        })->get();
+
+        $this->assertCount($zongaAmount, $products);
+
+        foreach ($products as $product) {
+            $this->assertInstanceOf(Product::class, $product);
+            $this->assertStringContainsString('<em>Zonga</em>', $product->highlight['title'][0]);
+        }
+    }
+}

--- a/tests/laravel/app/Library/HighlightedHitsIteratorAggregate.php
+++ b/tests/laravel/app/Library/HighlightedHitsIteratorAggregate.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Library;
+
+use ArrayIterator;
+use Illuminate\Support\Collection;
+use Laravel\Scout\Builder;
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+
+/**
+ * The example from the "Working with results" section of the README.
+ */
+final class HighlightedHitsIteratorAggregate implements HitsIteratorAggregate
+{
+    private array $results;
+
+    /** @var callable|null */
+    private $callback;
+
+    public function __construct(array $results, ?callable $callback = null)
+    {
+        $this->results = $results;
+        $this->callback = $callback;
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        $hits = $this->results['hits']['hits'] ?? [];
+
+        // MixedSearch can return hits of different classes.
+        // Group them by class and load each group with one query.
+        $models = collect($hits)
+            ->groupBy('_source.__class_name')
+            ->flatMap(function (Collection $classHits, string $class) {
+                $model = new $class;
+                $model->setKeyType('string');
+
+                $builder = new Builder($model, '');
+
+                // Keep the ->query() callback so eager loading still works.
+                if ($this->callback) {
+                    $builder->query($this->callback);
+                }
+
+                return $model->getScoutModelsByIds($builder, $classHits->pluck('_id')->all())
+                    ->keyBy(function ($model) use ($class) {
+                        return $class.'::'.$model->getScoutKey();
+                    });
+            });
+
+        // Sort the models in the same order as the hits
+        // and copy the highlights to each model.
+        $result = collect($hits)->map(function (array $hit) use ($models) {
+            $model = $models->get(($hit['_source']['__class_name'] ?? '').'::'.$hit['_id']);
+
+            // The document is in the index, but the model is not in the database.
+            if ($model === null) {
+                return null;
+            }
+
+            $model->highlight = $hit['highlight'] ?? [];
+
+            return $model;
+        })->filter()->values()->all();
+
+        return new ArrayIterator($result);
+    }
+}


### PR DESCRIPTION
## Problem

The `Working with results` section is three lines. It says to implement your own `HitsIteratorAggregate` and bind it in a service provider, then links to an issue. There is no example, so people have to read `ElasticSearchEngine::map()` and `EloquentHitsIteratorAggregate` to find out what the class must look like.

This is the section people land on when they want highlights in the result, so it is worth a real example.

## What changed

The section now has a full worked example for highlights:

1. the search callback that adds a `Highlight` to the DSL body
2. a custom `HitsIteratorAggregate` that merges the fragments onto the hydrated models
3. the service provider binding
4. how to read the fragments

Plus short notes on the constructor signature the container needs, why the `->query()` callback must reach the `Builder` (otherwise eager loading breaks), the Eloquent attribute caveat of `$model->highlight = ...`, and where aggregations live.

The wording is kept simple for non-native speakers.

The second commit puts the documented class in the test app and covers it with `tests/Feature/HighlightedResultsTest.php`, so the example cannot rot silently. Drop that commit if you want the PR to stay docs-only.

## Verified

Run against a live cluster, not only read:

- Elasticsearch 7.17.28, the same image the workflow uses, with `xpack.security.enabled=false`
- the new test passes: it indexes products, searches with a `Highlight` in the callback, and asserts every returned model carries its fragment
- full suite green on PHP 8.1.34, the version master's own docker stack builds: `OK (77 tests, 157 assertions)`

The example uses no syntax newer than PHP 7.4, so it is fine on the `^8.0.12` floor.

## Notes

`8.x` needs a different text, because the `ElasticParams` trait already covers score and highlight there. That is #329, on top of `feature/parallel-import-v2`.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)