### PR TITLE
Document how to work with results (8.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,11 +377,164 @@ In this example you will get collection of `Ticket` and `Book` models where tick
 book title is `Barcelona`
 
 ### Working with results
-Often your response isn't collection of models but aggregations or models with higlights andd so on.
-In this case you can use the 'ElasticParams' trait within your model to acquire the returned model score and highlight.
-In case you need additional data witin your results you need to implement your own implementation of `HitsIteratorAggregate` and bind it in your service provider.
 
-[Here is a case](https://github.com/matchish/laravel-scout-elasticsearch/issues/28)
+Sometimes you need more than models in the result. For example, the highlighted text or the score of each hit.
+
+#### Score and highlights
+
+Add the `ElasticParams` trait to your model:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+use Matchish\ScoutElasticSearch\Traits\ElasticParams;
+
+class Product extends Model
+{
+    use Searchable, ElasticParams;
+}
+```
+
+Elasticsearch does not send highlights by default. Add a `Highlight` object to the search body in a callback:
+
+```php
+use ONGR\ElasticsearchDSL\Highlight\Highlight;
+
+$products = Product::search('zonga', function (\Elastic\Elasticsearch\Client $client, $body) {
+    $highlight = new Highlight();
+    $highlight->addField('title');
+    $highlight->addField('description');
+
+    $body->addHighlight($highlight);
+
+    return $client->search([
+        'index' => (new Product)->searchableAs(),
+        'body' => $body->toArray(),
+    ])->asArray();
+})->get();
+```
+
+Now you can read both values from every model:
+
+```php
+foreach ($products as $product) {
+    $product->getElasticsearchScore();     // 1.4508327
+    $product->getElasticsearchHighlight(); // ['title' => ['<em>zonga</em> sneakers']]
+}
+```
+
+The score is always there. The highlighted text is there only when you ask Elasticsearch for it.
+
+#### Other data from the response
+
+The trait gives you the score and the highlighted text. For anything else, build the result yourself.
+
+The engine builds the result collection with a `HitsIteratorAggregate` taken from the container. You can bind your own class there and put anything you want into the result.
+
+The example below keeps the whole hit on every model:
+
+```php
+namespace App\Search;
+
+use ArrayIterator;
+use Illuminate\Support\Collection;
+use Laravel\Scout\Builder;
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+
+final class HitsWithRawDataIteratorAggregate implements HitsIteratorAggregate
+{
+    /** @var array<mixed> */
+    private array $results;
+
+    /** @var callable|null */
+    private $callback;
+
+    /**
+     * @param  array<mixed>  $results
+     */
+    public function __construct(array $results, ?callable $callback = null)
+    {
+        $this->results = $results;
+        $this->callback = $callback;
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        $hits = $this->results['hits']['hits'] ?? [];
+
+        // MixedSearch can return hits of different classes.
+        // Group them by class and load each group with one query.
+        $models = collect($hits)
+            ->groupBy('_source.__class_name')
+            ->flatMap(function (Collection $classHits, string $class) {
+                $model = new $class;
+                $model->setKeyType('string');
+
+                $builder = new Builder($model, '');
+
+                // Keep the ->query() callback so eager loading still works.
+                if ($this->callback) {
+                    $builder->query($this->callback);
+                }
+
+                return $model->getScoutModelsByIds($builder, $classHits->pluck('_id')->all())
+                    ->keyBy(function ($model) use ($class) {
+                        return $class.'::'.$model->getScoutKey();
+                    });
+            });
+
+        // Sort the models in the same order as the hits.
+        $result = collect($hits)->map(function (array $hit) use ($models) {
+            $model = $models->get(($hit['_source']['__class_name'] ?? '').'::'.$hit['_id']);
+
+            // The document is in the index, but the model is not in the database.
+            if ($model === null) {
+                return null;
+            }
+
+            // Your class replaces EloquentHitsIteratorAggregate,
+            // so fill the ElasticParams trait here as well.
+            $model->setElasticsearchScore((float) ($hit['_score'] ?? 0));
+            $model->setElasticsearchHighlight($hit['highlight'] ?? []);
+
+            $model->hit = $hit;
+
+            return $model;
+        })->filter()->values()->all();
+
+        return new ArrayIterator($result);
+    }
+}
+```
+
+Bind the class in a service provider:
+
+```php
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+use App\Search\HitsWithRawDataIteratorAggregate;
+...
+public function register(): void
+{
+    $this->app->bind(HitsIteratorAggregate::class, HitsWithRawDataIteratorAggregate::class);
+}
+```
+
+Now every model carries its hit:
+
+```php
+foreach ($products as $product) {
+    $product->hit['_index'];
+    $product->hit['sort'] ?? null;
+}
+```
+
+#### Good to know
+
+- The engine creates your class with `makeWith(['results' => ..., 'callback' => ...])`. Do not change the constructor signature.
+- `$callback` is the callback from the Scout `->query()` method. Give it to the `Builder`. If you skip this, eager loading with `->query()` no longer works.
+- Your class replaces `EloquentHitsIteratorAggregate`. The `ElasticParams` trait is filled there, so the score and the highlighted text stay empty until you set them yourself. Remove those two lines if your model does not use the trait.
+- `$model->hit = ...` creates a normal model attribute. It appears in `toArray()`, and `save()` tries to write a `hit` column. To avoid this, declare `public array $hit = [];` in your model. Then PHP sets a real property, and Eloquent does not see an attribute.
+- Aggregations are in `$this->results['aggregations']`. You can read them in the same class. If you need only the raw response, call `->raw()` instead.
 
 ## :free: License
 Scout ElasticSearch is an open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/tests/Feature/HighlightedResultsTest.php
+++ b/tests/Feature/HighlightedResultsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Library\HitsWithRawDataIteratorAggregate;
+use App\Product;
+use Elastic\Elasticsearch\Client;
+use Illuminate\Support\Facades\Artisan;
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+use ONGR\ElasticsearchDSL\Highlight\Highlight;
+use Tests\IntegrationTestCase;
+
+/**
+ * Covers the examples in the "Working with results" section of the README.
+ */
+final class HighlightedResultsTest extends IntegrationTestCase
+{
+    private int $zongaAmount;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        $this->zongaAmount = rand(2, 5);
+        factory(Product::class, $this->zongaAmount)->create(['title' => 'Zonga sneakers']);
+        factory(Product::class, rand(1, 3))->create(['title' => 'Amazon Kindle Fire']);
+
+        Product::setEventDispatcher($dispatcher);
+
+        Artisan::call('scout:import');
+    }
+
+    public function test_elastic_params_trait_gives_score_and_highlight(): void
+    {
+        $products = $this->searchWithHighlight();
+
+        $this->assertCount($this->zongaAmount, $products);
+
+        foreach ($products as $product) {
+            $this->assertGreaterThan(0, $product->getElasticsearchScore());
+            $this->assertStringContainsString(
+                '<em>Zonga</em>',
+                $product->getElasticsearchHighlight()['title'][0]
+            );
+        }
+    }
+
+    public function test_custom_hits_iterator_aggregate_keeps_the_whole_hit(): void
+    {
+        $this->app->bind(HitsIteratorAggregate::class, HitsWithRawDataIteratorAggregate::class);
+
+        $products = $this->searchWithHighlight();
+
+        $this->assertCount($this->zongaAmount, $products);
+
+        foreach ($products as $product) {
+            $this->assertInstanceOf(Product::class, $product);
+            // The hit carries the real index name, not the alias.
+            $this->assertStringStartsWith('products_', $product->hit['_index']);
+            $this->assertEquals($product->getScoutKey(), $product->hit['_id']);
+
+            // The custom class fills the trait itself.
+            $this->assertGreaterThan(0, $product->getElasticsearchScore());
+            $this->assertStringContainsString(
+                '<em>Zonga</em>',
+                $product->getElasticsearchHighlight()['title'][0]
+            );
+        }
+    }
+
+    private function searchWithHighlight()
+    {
+        return Product::search('zonga', function (Client $client, $body) {
+            $highlight = new Highlight();
+            $highlight->addField('title');
+
+            $body->addHighlight($highlight);
+
+            return $client->search([
+                'index' => (new Product)->searchableAs(),
+                'body' => $body->toArray(),
+            ])->asArray();
+        })->get();
+    }
+}

--- a/tests/laravel/app/Library/HitsWithRawDataIteratorAggregate.php
+++ b/tests/laravel/app/Library/HitsWithRawDataIteratorAggregate.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Library;
+
+use ArrayIterator;
+use Illuminate\Support\Collection;
+use Laravel\Scout\Builder;
+use Matchish\ScoutElasticSearch\ElasticSearch\HitsIteratorAggregate;
+
+/**
+ * The example from the "Working with results" section of the README.
+ */
+final class HitsWithRawDataIteratorAggregate implements HitsIteratorAggregate
+{
+    /** @var array<mixed> */
+    private array $results;
+
+    /** @var callable|null */
+    private $callback;
+
+    /**
+     * @param  array<mixed>  $results
+     */
+    public function __construct(array $results, ?callable $callback = null)
+    {
+        $this->results = $results;
+        $this->callback = $callback;
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        $hits = $this->results['hits']['hits'] ?? [];
+
+        // MixedSearch can return hits of different classes.
+        // Group them by class and load each group with one query.
+        $models = collect($hits)
+            ->groupBy('_source.__class_name')
+            ->flatMap(function (Collection $classHits, string $class) {
+                $model = new $class;
+                $model->setKeyType('string');
+
+                $builder = new Builder($model, '');
+
+                // Keep the ->query() callback so eager loading still works.
+                if ($this->callback) {
+                    $builder->query($this->callback);
+                }
+
+                return $model->getScoutModelsByIds($builder, $classHits->pluck('_id')->all())
+                    ->keyBy(function ($model) use ($class) {
+                        return $class.'::'.$model->getScoutKey();
+                    });
+            });
+
+        // Sort the models in the same order as the hits.
+        $result = collect($hits)->map(function (array $hit) use ($models) {
+            $model = $models->get(($hit['_source']['__class_name'] ?? '').'::'.$hit['_id']);
+
+            // The document is in the index, but the model is not in the database.
+            if ($model === null) {
+                return null;
+            }
+
+            // Your class replaces EloquentHitsIteratorAggregate,
+            // so fill the ElasticParams trait here as well.
+            $model->setElasticsearchScore((float) ($hit['_score'] ?? 0));
+            $model->setElasticsearchHighlight($hit['highlight'] ?? []);
+
+            $model->hit = $hit;
+
+            return $model;
+        })->filter()->values()->all();
+
+        return new ArrayIterator($result);
+    }
+}


### PR DESCRIPTION
Same docs work as #328, adapted for this branch. Based on `feature/parallel-import-v2`, so it can be merged after that branch lands.

## Problem

The `Working with results` section names the `ElasticParams` trait and the `HitsIteratorAggregate` interface, but shows no code. People have to read `ElasticSearchEngine::map()` and `EloquentHitsIteratorAggregate` to find out how to use either one.

## What changed

The section is now split in two.

**Score and highlights**, the short path most people want:

1. add the `ElasticParams` trait to the model
2. ask Elasticsearch for highlights with a search callback (they are off by default)
3. read `getElasticsearchScore()` and `getElasticsearchHighlight()`

**Other data from the response**, for everything the trait does not cover: a full custom `HitsIteratorAggregate` that keeps the whole hit on every model, and the service provider binding.

The notes at the end cover the constructor signature the container needs, why the `->query()` callback must reach the `Builder`, the Eloquent attribute caveat, and where aggregations live.

One point worth a second look: a custom class replaces `EloquentHitsIteratorAggregate`, which is where the `ElasticParams` trait gets filled. So the example calls `setElasticsearchScore()` and `setElasticsearchHighlight()` itself. This is easy to miss and silently loses the highlights.

The wording is kept simple for non-native speakers.

The second commit puts the documented class in the test app and covers both paths with `tests/Feature/HighlightedResultsTest.php`. Drop that commit if you want the PR to stay docs-only.

## Verified

Run against a live cluster, not only read:

- Elasticsearch 7.17.28, the same image the workflow uses, with `xpack.security.enabled=false`
- the trait path passes: score is set and the fragment comes back on every model
- the custom class path passes, including the assertion that it fills the trait itself
- full suite green: `OK (120 tests, 287 assertions)`

One detail found while testing: `$hit['_index']` holds the real index name, for example `products_1525376494`, not the `products` alias. The test asserts the prefix.

## Notes

The `7.x` version is #328 against `master`. It has no trait, so the text there is different.

Refs #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)