### PR TITLE
Cover routing guard with unit tests, fix CHANGELOG and PHPUnit config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [7.2.2] - 2023-06-06
 ### Fixed
-- [No duplicates in search on reindex anymore. updates/inserts will be visible only after reindex. For most projects should be ok but for some could be breaking changes](https://github.com/matchish/laravel-scout-elasticsearch/issues/247)
+- [Check the `routing` attribute is loaded before reading it, so models using `preventAccessingMissingAttributes` no longer throw `MissingAttributeException`](https://github.com/matchish/laravel-scout-elasticsearch/issues/247)
 
 ## [7.0.0] - 2023-02-01
 ### Changed

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,9 +20,9 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/Unit/ElasticSearch/Params/BulkTest.php
+++ b/tests/Unit/ElasticSearch/Params/BulkTest.php
@@ -3,11 +3,20 @@
 namespace Tests\Unit\ElasticSearch\Params;
 
 use App\Product;
+use Illuminate\Database\Eloquent\Model;
 use Matchish\ScoutElasticSearch\ElasticSearch\Params\Bulk;
 use Tests\TestCase;
 
 class BulkTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        // The flag is a global static, so reset it to not affect other tests.
+        Model::preventAccessingMissingAttributes(false);
+
+        parent::tearDown();
+    }
+
     public function test_delete()
     {
         $bulk = new Bulk();
@@ -65,6 +74,41 @@ class BulkTest extends TestCase
                 ['index' => ['_index' => 'products', '_id' => 'Scout', 'routing' => 'Scout']],
                 ['title' => 'Scout', 'id' => 2, '__class_name' => 'App\Product'],
             ],
+        ], $params);
+    }
+
+    public function test_index_model_without_routing_attribute()
+    {
+        Model::preventAccessingMissingAttributes();
+        $bulk = new Bulk();
+        $product = new Product(['title' => 'Scout']);
+        $product->id = 2;
+        // Only a model loaded from the database triggers the strict check.
+        $product->exists = true;
+        $bulk->index($product);
+        $params = $bulk->toArray();
+
+        $this->assertEquals([
+            'body' => [
+                ['index' => ['_index' => 'products', '_id' => 2, 'routing' => 2]],
+                ['title' => 'Scout', 'id' => 2, '__class_name' => 'App\Product'],
+            ],
+        ], $params);
+    }
+
+    public function test_delete_model_without_routing_attribute()
+    {
+        Model::preventAccessingMissingAttributes();
+        $bulk = new Bulk();
+        $product = new Product(['title' => 'Scout']);
+        $product->id = 2;
+        // Only a model loaded from the database triggers the strict check.
+        $product->exists = true;
+        $bulk->delete($product);
+        $params = $bulk->toArray();
+
+        $this->assertEquals([
+            'body' => [['delete' => ['_index' => 'products', '_id' => 2, 'routing' => 2]]],
         ], $params);
     }
 


### PR DESCRIPTION
Follow-up to [#247](https://github.com/matchish/laravel-scout-elasticsearch/issues/247), which is now closed. No production code changes — `src/` is untouched.

### Unit tests for the routing guard

`Bulk::toArray()` guards both the index and the delete path, so it never reads `$model->routing` unless the attribute is loaded. Until now only the integration suite covered this, via `Product::preventAccessingMissingAttributes()` in `IntegrationTestCase`. That needs a running Elasticsearch.

The obvious unit test would have been useless. `MissingAttributeException` is thrown only when the model has `exists = true`:

```php
if ($this->exists &&
    ! $this->wasRecentlyCreated &&
    static::preventsAccessingMissingAttributes()) {
```

Every existing test builds the model with `new Product([...])`, which leaves `exists = false`. So the new tests set `$product->exists = true`. This also explains why only the integration tests caught the original bug: models loaded from the database have `exists = true`.

Verified by removing both guards and re-running. Both new tests fail with the exact error from the issue, while the 5 original tests still pass:

```
1) BulkTest::test_index_model_without_routing_attribute
Illuminate\Database\Eloquent\MissingAttributeException: The attribute [routing]
either does not exist or was not retrieved for model [App\Product].
```

`tearDown()` resets the flag, because `preventAccessingMissingAttributes()` is a global static on `Model`, not per-model, and would otherwise leak into later tests.

### CHANGELOG

The 7.2.2 entry linked #247 but its text was copy-pasted from the 7.0.0 entry about reindex duplicates, which is an unrelated change. Replaced with a description of the actual fix.

### PHPUnit config

`vendor/bin/phpunit` printed this on every run:

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

The deprecated part is the `<filter><whitelist>` coverage block. Replaced with `<coverage><include>`. I ran PHPUnit's own `--migrate-configuration` to get the correct mapping, then applied only that change by hand — the tool also collapses every attribute onto one line, which would have made the diff much larger for no benefit.

This was only a warning; it did not fail the build.

### Testing

Full suite on this branch's own dependency set (PHP 8.1.34, PHPUnit 9.6.36, Laravel 10.x-dev, testbench 8.38), against MySQL 8 and Elasticsearch 7.17.28:

```
OK (78 tests, 154 assertions)
```

Exit code 0, and the schema warning is gone. `--coverage-clover` still accepts the new config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
